### PR TITLE
Allow disable colours

### DIFF
--- a/src/python/esgcet/esgcet/config/etc/template.ini
+++ b/src/python/esgcet/esgcet/config/etc/template.ini
@@ -192,6 +192,9 @@ project_options =
   cmip6 | CMIP6  | 2
   test | Test Project | 3
 
+# disable_colors : set to true to disable colors in publisher terminal output
+disable_colors = False
+
 #------------------------------------------------------------------------------------------
 # Database initialization
 # Options in this section are used by esginitialize.

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -73,7 +73,6 @@ class Bcolors:
                 self._disable_colors = \
                     config.getboolean('DEFAULT', 'disable_colors',
                                       default=False)
-                print "DISABLE COLORS = ", self._disable_colors
             else:
                 return False  # allow colors until config is loaded
         return self._disable_colors                

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -27,20 +27,59 @@ os.stat_float_times(False)
 UPDATE_TIMESTAMP = "/tmp/publisher-last-check"
 
 class Bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+
+    @property
+    def HEADER(self):
+        return self._get_escape('95')
+
+    @property
+    def OKBLUE(self):
+        return self._get_escape('94')
+
+    @property
+    def OKGREEN(self):
+        return self._get_escape('92')
+
+    @property
+    def WARNING(self):
+        return self._get_escape('93')
+
+    @property
+    def FAIL(self):
+        return self._get_escape('91')
+
+    @property
+    def ENDC(self):
+        return self._get_escape('0')
+
+    @property
+    def BOLD(self):
+        return self._get_escape('1')
+
+    @property
+    def UNDERLINE(self):
+        return self._get_escape('4')
+
+    def _get_escape(self, val):
+        if self._colors_are_disabled():
+            return ''
+        else:
+            return('\033[{}m'.format(val))
+
+    def _colors_are_disabled(self):
+        if self._disable_colors == None:
+            config = getConfig()
+            if config:
+                self._disable_colors = \
+                    config.getboolean('DEFAULT', 'disable_colors',
+                                      default=False)
+                print "DISABLE COLORS = ", self._disable_colors
+            else:
+                return False  # allow colors until config is loaded
+        return self._disable_colors                
 
     def __init__(self):
-        if "ESGPUBLISH_DISABLE_COLORS" in os.environ:
-            for key in dir(self):
-                if isinstance(key, str) and not key.startswith('__'):
-                    setattr(self, key, '')
+        self._disable_colors = None
 
 bcolors = Bcolors()
 

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -26,7 +26,9 @@ os.stat_float_times(False)
 
 UPDATE_TIMESTAMP = "/tmp/publisher-last-check"
 
-class bcolors:
+
+
+class Bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
@@ -36,6 +38,13 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+    def __init__(self):
+        if "ESGPUBLISH_DISABLE_COLORS" in os.environ:
+            for key in dir(self):
+                if isinstance(key, str) and not key.startswith('__'):
+                    setattr(self, key, '')
+
+bcolors = Bcolors()
 
 def getTypeAndLen(att):
     """Get the type descriptor of an attribute.

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -26,8 +26,6 @@ os.stat_float_times(False)
 
 UPDATE_TIMESTAMP = "/tmp/publisher-last-check"
 
-
-
 class Bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'


### PR DESCRIPTION
Gives node managers a way to turn off colours by setting esg.ini variable `disable_colors = True` (in section `[DEFAULT]`). Defaults to false (i.e. colours permitted) if not set.

Depending on the terminal settings, the colours might not be helpful, and might make the text illegible. Example:
![screenshot](https://user-images.githubusercontent.com/5577313/35196483-7c60a0c0-feca-11e7-98e4-6bd2129fd44a.png)