### PR TITLE
prevent calling PrePARE for CMIP6 in replicas

### DIFF
--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -19,7 +19,8 @@ version_pattern = re.compile('20\d{2}[0,1]\d[0-3]\d')
 
 class CMIP6Handler(BasicHandler):
 
-    def __init__(self, name, path, Session, validate=True, offline=False):
+    def __init__(self, name, path, Session, validate=True, offline=False, replica=False):
+        self.replica = replica
         BasicHandler.__init__(self, name, path, Session, validate=validate, offline=offline)
 
     def openPath(self, path):
@@ -41,6 +42,10 @@ class CMIP6Handler(BasicHandler):
         validator = PrePARE.PrePARE
 
         f = fileobj.path
+
+        if self.replica:
+            debug("skipping PrePARE for replica (file %s)" % f)
+            return
 
         # todo refactoring these could loaded upfront in the constructor
         config = getConfig()

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -593,7 +593,7 @@ def datasetMapIterator(datasetMap, datasetId, versionNumber, extraFields=None, o
 def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, operation, filefilt, initcontext, offlineArg,
                         properties, testProgress1=None, testProgress2=None, handlerDictionary=None, perVariable=None, keepVersion=False, newVersion=None,
                         extraFields=None, masterGateway=None, comment=None, forceAggregate=False, readFiles=False, nodbwrite=False,
-                        pid_connector=None):
+                        pid_connector=None, handlerExtraArgs={}):
     """
     Scan and aggregate (if possible) a list of datasets. The datasets and associated files are specified
     in one of two ways: either as a *dataset map* (see ``dmap``) or a *directory map* (see ``directoryMap``).
@@ -655,6 +655,9 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
 
     handlerDictionary=None
       A dictionary mapping datasetName => handler. If None, handlers are determined by project name.
+
+    handlerExtraArgs={}
+      A dictionary of extra keyword arguments to pass when instantiating the handler.
 
     perVariable=None
       Boolean, overrides ``variable_per_file`` config option.
@@ -744,9 +747,9 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
         if handlerDictionary is not None and handlerDictionary.has_key(datasetName):
             handler = handlerDictionary[datasetName]
         elif projectName is not None:
-            handler = getHandlerByName(projectName, firstFile, Session, validate=True, offline=offline)
+            handler = getHandlerByName(projectName, firstFile, Session, validate=True, offline=offline, **handlerExtraArgs)
         else:
-            handler = getHandler(firstFile, Session, validate=True)
+            handler = getHandler(firstFile, Session, validate=True, **handlerExtraArgs)
             if handler is None:
                 raise ESGPublishError("No project found in file %s, specify with --project."%firstFile)
             projectName = handler.name

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -590,7 +590,12 @@ def main(argv):
     if restApi is None:
         restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
 
-    handler = getHandlerByName(projectName, None, Session, offline=offline)
+    # Set up dictionary of extra handler args.
+    # (Any not supported by the handler will be filtered out.)
+    handler_extra_args = {'replica': (masterGateway != None)}        
+
+    # get the handler
+    handler = getHandlerByName(projectName, None, Session, offline=offline, **handler_extra_args)
 
     # check cert and generate a new one, if expired
     if publish and not keep_credentials:
@@ -633,7 +638,7 @@ def main(argv):
                         datasets = iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, publishOp,
                                                        filefilt, initcontext, offline, properties, keepVersion=keepVersion, newVersion=version,
                                                        extraFields=extraFields, masterGateway=masterGateway, comment=message, readFiles=readFiles,
-                                                       nodbwrite=nodbwrite, pid_connector=pid_connector)
+                                                       nodbwrite=nodbwrite, pid_connector=pid_connector, handlerExtraArgs=handler_extra_args)
 
                     if (not nodbwrite):
                         result = publishDatasetList(datasetNames, Session, publish=publish, thredds=thredds, las=las, parentId=parent, service=service,
@@ -710,7 +715,7 @@ def main(argv):
                 datasets = iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, publishOp, filefilt,
                                                initcontext, offline, properties, keepVersion=keepVersion, newVersion=version, extraFields=extraFields,
                                                masterGateway=masterGateway, comment=message, readFiles=readFiles, nodbwrite=nodbwrite,
-                                               pid_connector=pid_connector)
+                                               pid_connector=pid_connector, handlerExtraArgs=handler_extra_args)
 
             if (not nodbwrite):
                 result = publishDatasetList(datasetNames, Session, publish=publish, thredds=thredds, las=las, parentId=parent, service=service,


### PR DESCRIPTION
add functionality to pass extra args to the handler where the handler supports them, and actually pass a "handler" arg (boolean) based on whether --set-replica is set, and add support for it in CMIP6 handler so that it suppresses calling PrePARE