### PR TITLE
report name of top_dir in CIM error

### DIFF
--- a/src/python/esgcet/esgcet/publish/cim.py
+++ b/src/python/esgcet/esgcet/publish/cim.py
@@ -63,7 +63,7 @@ class Cdf2cimWrapper:
             try:
                 self._call_cdf2cim(top_dir)
             except:
-                failures += "While running cdf2cim on 'top_dir':\n%s" % tracebackString(indent=5)
+                failures += "While running cdf2cim on '%s':\n%s" % (top_dir, tracebackString(indent=5))
 
         if failures:
             raise Exception(failures)


### PR DESCRIPTION
a token that was meant to be substituted had got left in as literal - fixing