### PR TITLE
Simplifies call to PrePARE 3.3.1 + cleanup code

### DIFF
--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -1,15 +1,12 @@
 """"Handle CMIP6 data file metadata"""
 
-import argparse
 import re
-import sys
 
 from cmip6_cv import PrePARE
 from esgcet.config import BasicHandler, getConfig, compareLibVersions, splitRecord
 from esgcet.exceptions import *
 from esgcet.messaging import debug, warning
 from esgcet.publish import checkAndUpdateRepo
-from cdms2 import Cdunif
 
 WARN = False
 
@@ -87,34 +84,15 @@ class CMIP6Handler(BasicHandler):
 
         checkAndUpdateRepo(cmor_table_path, data_specs_version)
 
-        table_file = cmor_table_path + '/CMIP6_' + table + '.json'
-        fakeargs = [ '--variable', variable_id, table_file ,f]
-        parser = argparse.ArgumentParser(prog='esgpublisher')
-        parser.add_argument('--variable')
-        parser.add_argument('cmip6_table', action=validator.JSONAction)
-        parser.add_argument('infile', action=validator.CDMSAction)
-        parser.add_argument('outfile',
-                nargs='?',
-                help='Output file (default stdout)',
-                type=argparse.FileType('w'),
-                default=sys.stdout)
-        args = parser.parse_args(fakeargs)
-
-#        print "About to CV check:", f
-
         try:
-            process = validator.checkCMIP6(args)
+            process = validator.checkCMIP6(cmor_table_path)
             if process is None:
                 raise ESGPublishError("File %s failed the CV check - object create failure"%f)
-            args.infile = Cdunif.CdunifFile(args.infile,"r")
-            process.ControlVocab(args)
-            args.infile.close()
-
+            process.ControlVocab(f)
         except:
-
             raise ESGPublishError("File %s failed the CV check"%f)
 
-    def check_pid_avail(self, project_config_section, config, version=None):
+    def check_pid_avail(self, version=None):
         """ Returns the pid_prefix
 
          project_config_section
@@ -179,7 +157,7 @@ class CMIP6Handler(BasicHandler):
 
         return pid_messaging_service_exchange_name, pid_messaging_service_credentials
 
-    def get_citation_url(self, project_section, config, dataset_name, dataset_version, test_publication):
+    def get_citation_url(self, dataset_name, dataset_version, test_publication):
         """ Returns the citation_url if a project uses citation, otherwise returns None
 
          project_section


### PR DESCRIPTION
PrePARE call in ``cmip6_handler.py`` needs changes according to CMOR 3.3.1. Fake args are useless now.