### PR TITLE
change logic over whether to use REST api

### DIFF
--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -104,6 +104,8 @@ Options:
 
     -h, --help: Print a help message.
 
+    --hessian-api: Use the legacy publishing API. See also --rest-api.
+
     -i init_dir:
         Directory containing all initialization files.
         Recommended: one initialization file for the default sections (esg.ini) and one per project, must match the name format esg.<project>.ini
@@ -212,6 +214,9 @@ Options:
         Publish using the RESTful publication services. The configuration file option ``rest_service_url''
         defines the service location. If it is undefined, the service location is
         https://HOST/esg-search/ws, where HOST is derived from configuration option ``hessian_service_url''.
+
+        If neither --rest-api nor --hessian-api are specified, then config file option use_rest_api is used,
+        and if this option is not found, the REST API is used by default.
 
     --service service_name
         Specify a THREDDS service name to associate with an offline dataset. If omitted, the name of the
@@ -358,7 +363,8 @@ def main(argv):
     readFiles = False
     rescan = False
     rescanDatasetName = []
-    restApi = True
+    restApi = None
+    restApiDefault = True
     schema = None
     service = None
     summarizeErrors = False
@@ -401,6 +407,8 @@ def main(argv):
         elif flag in ['-h', '--help']:
             print usage
             sys.exit(0)
+        elif flag=='--hessian-api':
+            restApi = False
         elif flag=='-i':
             init_dir = arg
         elif flag == '--keep-credentials':
@@ -588,7 +596,7 @@ def main(argv):
 
     # Get the default publication interface (REST or Hessian)
     if restApi is None:
-        restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
+        restApi = config.getboolean('DEFAULT', 'use_rest_api', default=restApiDefault)
 
     # Set up dictionary of extra handler args.
     # (Any not supported by the handler will be filtered out.)

--- a/src/python/esgcet/scripts/esgunpublish
+++ b/src/python/esgcet/scripts/esgunpublish
@@ -75,6 +75,8 @@ Options:
 
     -h, --help: Print a help message.
 
+    --hessian-api: Use the legacy publishing API. See also --rest-api.
+
     -i init_dir:
         Directory containing all initialization files.
         Recommended: one initialization file for the default sections (esg.ini) and one per project, must match the name format esg.<project>.ini
@@ -111,6 +113,10 @@ Options:
         https://HOST/esg-search/ws, where HOST is derived from configuration option ``hessian_service_url''.
 
         Note: With this option, the dataset_name should have the form 'dataset_id|data_node'.
+
+        If neither --rest-api nor --hessian-api are specified, then config file option use_rest_api is used,
+        and if this option is not found, the **legacy** API is used by default.
+        ** This contrasts with 'esgpublish' but it is intended to change this behavior in future. **
 
     --skip-index: Perform local (node) operations, skip SOLR index dataset delete.
 
@@ -182,7 +188,12 @@ def main(argv):
     las = False
     log_filename = None
     republish = True
-    restApi = False  # ska rolled back for v3.4.3 until reconcile changes
+    # ska set to false for v3.4.3 until reconcile changes
+    # (ami changed this to a default value that can be overridden in config;
+    # please update help text if setting this to True, see text marked with "**"
+    # under "--rest-api")
+    restApi = None
+    restApiDefault = False 
     thredds = True
     syncThredds = False
     useList = False
@@ -206,6 +217,8 @@ def main(argv):
         elif flag in ['-h', '--help']:
             print usage
             sys.exit(0)
+        elif flag=='--hessian-api':
+            rest_api = False
         elif flag=='-i':
             init_dir = arg
         elif flag == '--keep-credentials':
@@ -284,7 +297,7 @@ def main(argv):
 
     # Get the default publication interface (REST or Hessian)
     if restApi is None:
-        restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
+        restApi = config.getboolean('DEFAULT', 'use_rest_api', default=restApiDefault)
 
     if not data_node:
         data_node = urlparse.urlparse(config.get('DEFAULT', 'thredds_url')).netloc


### PR DESCRIPTION
Sets `restApi` to:
* default True in `esgpublish`,
* default False in `esgunpublish` but with a help message alerting that this is intended to change (per #74)

and adds command line flag `--hessian-api`

Order of precedence is:
* command-line option (`--rest-api` or `--hessian-api`)
* if not specified, `use_rest_api` in default
* if not set, use default value (per above)

Fixes a problem in existing code in esgpublish that had `restApi=True` at the top, and no way to override it except by editing the code.

**Warning**: untested, although it looks like it should straightforwardly work. Please treat the diff as a suggestion.