### PR TITLE
Add --commit-every flag to control how often to commit to DB when scanning files

### DIFF
--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -640,7 +640,7 @@ def datasetMapIterator(datasetMap, datasetId, versionNumber, extraFields=None, o
 def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, operation, filefilt, initcontext, offlineArg,
                         properties, testProgress1=None, testProgress2=None, handlerDictionary=None, perVariable=None, keepVersion=False, newVersion=None,
                         extraFields=None, masterGateway=None, comment=None, forceAggregate=False, readFiles=False, nodbwrite=False,
-                        pid_connector=None, test_publication=False, handlerExtraArgs={}):
+                        pid_connector=None, test_publication=False, handlerExtraArgs={}, commitEvery=None):
     """
     Scan and aggregate (if possible) a list of datasets. The datasets and associated files are specified
     in one of two ways: either as a *dataset map* (see ``dmap``) or a *directory map* (see ``directoryMap``).
@@ -736,6 +736,9 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
 
     pid_connector
         esgfpid.Connector object to register PIDs
+
+    commitEvery
+        Integer specifying how frequently to commit file info to database when scanning files
 
     """
     from esgcet.publish import extractFromDataset, aggregateVariables
@@ -852,7 +855,7 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
                                      offline=offline, operation=operation, progressCallback=testProgress1, perVariable=perVariable,
                                      keepVersion=keepVersion, newVersion=newVersion, extraFields=extraFields, masterGateway=masterGateway,
                                      comment=comment, useVersion=versionno, forceRescan=forceAggregate, nodbwrite=nodbwrite,
-                                     pid_connector=pid_connector, test_publication=test_publication, **context)
+                                     pid_connector=pid_connector, test_publication=test_publication, commitEvery=commitEvery, **context)
 
         # If republishing an existing version, only aggregate if online and no variables exist (yet) for the dataset.
 

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -389,10 +389,11 @@ def main(argv):
             publishOp = UPDATE_OP
         elif flag=='--commit-every':
             try:
-                commitEvery = int(arg)
-                assert commitEvery > 0
-            except (ValueError, AssertionError):
-                raise ESGPublishError('--commit-every must be a positive integer')
+                commitEvery = string.atoi(arg)
+                if commitEvery <= 0:
+                    raise ValueError
+            except ValueError:
+                raise ESGPublishError('--commit-every must be a positive integer: %s' % arg)
         elif flag in ['-c', '--create']:
             publishOp = CREATE_OP
         elif flag in ('--create-cim', '--no-create-cim', '--create-cim-only') and (createCim != None or createCimOnly):

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -57,8 +57,11 @@ Options:
         Name of the aggregate dimension. Defaults to 'time'
 
     --commit-every n
-        Commit file info to database every n files when adding a dataset. Default to commit once
+        Commit file info to database every n files when adding a dataset. By default commit once
         after all files are scanned.
+
+        This option can reduce memory usage, but if it is used, the dataset should be unpublished
+        if publication is interrupted.
 
     -c, --create
         Create and publish a dataset containing the files listed in the directory or dataset map.

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -56,6 +56,10 @@ Options:
     -a aggregate_dimension_name:
         Name of the aggregate dimension. Defaults to 'time'
 
+    --commit-every n
+        Commit file info to database every n files when adding a dataset. Default to commit once
+        after all files are scanned.
+
     -c, --create
         Create and publish a dataset containing the files listed in the directory or dataset map.
 
@@ -329,13 +333,14 @@ def yield_parsed_mapfiles(mapfileDir):
 def main(argv):
 
     try:
-        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'create', 'create-cim', 'create-cim-only', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-create-cim', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'verbose-cim-errors', 'nodbwrite'])
+        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'commit-every=', 'create', 'create-cim', 'create-cim-only', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-create-cim', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'verbose-cim-errors', 'nodbwrite'])
     except getopt.error:
         print sys.exc_value
         print usage
         sys.exit(0)
 
     aggregateDimension = "time"
+    commitEvery = None
     createCim = None  # default (behaviour depends on various options and project handler), not same as False
     createCimOnly = False
     verboseCimErrors = False
@@ -382,6 +387,12 @@ def main(argv):
             aggregateDimension = arg
         elif flag=='--append':
             publishOp = UPDATE_OP
+        elif flag=='--commit-every':
+            try:
+                commitEvery = int(arg)
+                assert commitEvery > 0
+            except (ValueError, AssertionError):
+                raise ESGPublishError('--commit-every must be a positive integer')
         elif flag in ['-c', '--create']:
             publishOp = CREATE_OP
         elif flag in ('--create-cim', '--no-create-cim', '--create-cim-only') and (createCim != None or createCimOnly):
@@ -646,7 +657,8 @@ def main(argv):
                         datasets = iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, publishOp,
                                                        filefilt, initcontext, offline, properties, keepVersion=keepVersion, newVersion=version,
                                                        extraFields=extraFields, masterGateway=masterGateway, comment=message, readFiles=readFiles,
-                                                       nodbwrite=nodbwrite, pid_connector=pid_connector, test_publication=test_publication, handlerExtraArgs=handler_extra_args)
+                                                       nodbwrite=nodbwrite, pid_connector=pid_connector, test_publication=test_publication,
+                                                       handlerExtraArgs=handler_extra_args, commitEvery=commitEvery)
 
                     if (not nodbwrite):
                         result = publishDatasetList(datasetNames, Session, publish=publish, thredds=thredds, las=las, parentId=parent, service=service,
@@ -723,7 +735,8 @@ def main(argv):
                 datasets = iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, aggregateDimension, publishOp, filefilt,
                                                initcontext, offline, properties, keepVersion=keepVersion, newVersion=version, extraFields=extraFields,
                                                masterGateway=masterGateway, comment=message, readFiles=readFiles, nodbwrite=nodbwrite,
-                                               pid_connector=pid_connector, test_publication=test_publication, handlerExtraArgs=handler_extra_args)
+                                               pid_connector=pid_connector, test_publication=test_publication, handlerExtraArgs=handler_extra_args,
+                                               commitEvery=commitEvery)
 
             if (not nodbwrite):
                 result = publishDatasetList(datasetNames, Session, publish=publish, thredds=thredds, las=las, parentId=parent, service=service,


### PR DESCRIPTION
Add a new command line option `--commit-every n` that will cause the publisher to commit file info to the database after every `n` files when scanning files.

This reduces memory consumption when publishing datasets with a large number of files, since information about each file is not held in memory throughout the whole publication.

Existing behaviour is preserved if the option is not given. 