### PR TITLE
Add 'skip_aggregations' option in project specific config file

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -498,6 +498,10 @@ The project specific config files: esg.<project>.ini
             monClim | 1 month
             fx      | fixed
 
+#. (Optional) The ``skip_aggregations`` option:
+
+    If ``skip_aggregations`` is set to ``true``, aggregations will not be created. By default this option is set to ``false``.
+
 .. _policies:
 
 Prepare user and permissions for publication

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -861,6 +861,17 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
             runAggregate = (runAggregate and dataset.reaggregate)
         runAggregate = runAggregate or forceAggregate
 
+        # Turn off aggregations if skip_aggregations is set
+        # This applies even if forceAggregate is set to True elsewhere in the
+        # code when republishing an earlier version of the dataset
+        section = 'project:%s' % context.get('project')
+        config = getConfig()
+        skipAggregate = config.getboolean(section, 'skip_aggregations', False)
+
+        if runAggregate and skipAggregate:
+            runAggregate = False
+            info("Skipping aggregations due to skip_aggregations config option")
+
         if testProgress2 is not None:
            testProgress2[1] = (100./ct)*iloop + 50./ct
            testProgress2[2] = (100./ct)*(iloop + 1)

--- a/src/python/esgcet/scripts/esgunpublish
+++ b/src/python/esgcet/scripts/esgunpublish
@@ -152,7 +152,8 @@ def republishDataset(result, Session, thredds, gatewayOp):
     """
     Republish previous versions as needed. This will happen if the latest version
     was deleted from the database, and is not
-    the only version. In this case the previous version will be rescanned to generate the aggregations.
+    the only version. In this case the previous version will be rescanned to generate the aggregations
+    (unless user has overridden with skip_aggregations in project config)
     """
     statusDict, republishList = result
     if len(republishList)>0:


### PR DESCRIPTION
If set to true, aggregations are not created. By default it is set to false which preserves existing behaviour.

We have a project where aggregations are not required, and skipping the aggregation step saves a considerable amount of time during publication.