### PR TITLE
CMOR tables related changes (for CMIP6)

### DIFF
--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -1,12 +1,13 @@
 """"Handle CMIP6 data file metadata"""
 
+import logging
 import re
 
 from cmip6_cv import PrePARE
 from esgcet.config import BasicHandler, getConfig, compareLibVersions, splitRecord
 from esgcet.exceptions import *
-from esgcet.messaging import debug, warning
-from esgcet.publish import checkAndUpdateRepo
+from esgcet.messaging import debug, info, warning
+from esgcet.publish import getTableDir
 
 WARN = False
 
@@ -41,10 +42,6 @@ class CMIP6Handler(BasicHandler):
 
         f = fileobj.path
 
-        if self.replica:
-            debug("skipping PrePARE for replica (file %s)" % f)
-            return
-
         # todo refactoring these could loaded upfront in the constructor
         config = getConfig()
         project_section = 'project:' + self.name
@@ -53,17 +50,25 @@ class CMIP6Handler(BasicHandler):
         min_ds_version = config.get(project_section, "min_data_specs_version", default="0.0.0")
         data_specs_version = config.get(project_config_section, "data_specs_version", default="master")
         cmor_table_path = config.get(project_config_section, "cmor_table_path", default=DEFAULT_CMOR_TABLE_PATH)
+        force_validation = config.getboolean(project_config_section, "force_validation", default=False)
+        cmor_table_subdirs = config.getboolean(project_config_section, "cmor_table_subdirs", default=False)
 
-        try:
-            file_cmor_version = fileobj.getAttribute('cmor_version', None)
-        except:
-            file_cmor_version = None
-            debug('File %s missing cmor_version attribute; will proceed with PrePARE check' % f)
+        if not force_validation:
 
-        passed_cmor = False
-        if compareLibVersions(min_cmor_version, file_cmor_version):
-            debug('File %s cmor-ized at version %s, passed!"'%(f, file_cmor_version))
-            passed_cmor = True
+            if self.replica:
+                info("skipping PrePARE for replica (file %s)" % f)
+                return
+
+            try:
+                file_cmor_version = fileobj.getAttribute('cmor_version', None)
+            except:
+                file_cmor_version = None
+                debug('File %s missing cmor_version attribute; will proceed with PrePARE check' % f)
+
+            passed_cmor = False
+            if compareLibVersions(min_cmor_version, file_cmor_version):
+                debug('File %s cmor-ized at version %s, passed!'%(f, file_cmor_version))
+                passed_cmor = True
 
         try:
             table = fileobj.getAttribute('table_id', None)
@@ -90,16 +95,17 @@ class CMIP6Handler(BasicHandler):
         # at this point the file has the correct data specs version.
         # if also was CMORized and has the correct version tag, we can exit
 
-        if passed_cmor:
+        if (not force_validation) and passed_cmor:
             return
             
         if data_specs_version == "file":
             data_specs_version = file_data_specs_version
 
-        checkAndUpdateRepo(cmor_table_path, data_specs_version)
+        table_dir = getTableDir(cmor_table_path, data_specs_version, cmor_table_subdirs)
+        debug("Validating {} using tables dir: {}".format(f, table_dir))
 
         try:
-            process = validator.checkCMIP6(cmor_table_path)
+            process = validator.checkCMIP6(table_dir)
             if process is None:
                 raise ESGPublishError("File %s failed the CV check - object create failure"%f)
             process.ControlVocab(f)

--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -1,6 +1,5 @@
 """"Handle CMIP6 data file metadata"""
 
-import logging
 import re
 
 from cmip6_cv import PrePARE

--- a/src/python/esgcet/esgcet/publish/__init__.py
+++ b/src/python/esgcet/esgcet/publish/__init__.py
@@ -5,7 +5,7 @@ from extract import extractFromDataset, aggregateVariables, CREATE_OP, DELETE_OP
 from utility import filelistIterator, fnmatchIterator, fnIterator, directoryIterator, multiDirectoryIterator,\
     nodeIterator, progressCallback, StopEvent, readDatasetMap, datasetMapIterator, iterateOverDatasets,\
     processIterator, processNodeMatchIterator, checksum, extraFieldsGet, parseDatasetVersionId,\
-    generateDatasetVersionId, compareFilesByPath, establish_pid_connection, bcolors, checkAndUpdateRepo, tracebackString
+    generateDatasetVersionId, compareFilesByPath, establish_pid_connection, bcolors, checkAndUpdateRepo, getTableDir, tracebackString
 from thredds import generateThredds, reinitializeThredds, generateThreddsOutputPath, updateThreddsMasterCatalog, updateThreddsRootCatalog
 from hessianlib import Hessian, RemoteCallException
 from unpublish import deleteDatasetList, DELETE, UNPUBLISH, NO_OPERATION, UNINITIALIZED

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -1121,6 +1121,40 @@ def establish_pid_connection(pid_prefix, test_publication, project_config_sectio
     return pid_connector
 
 
+def getTableDir(cmor_table_path, ds_version, use_subdirs):
+    """
+    Get the directory of CMOR tables appropriate for use by PrePARE for checking 
+    against version ds_version, using one of two strategies.
+
+    If use_subdirs=False, assume that the cmor_table_path is a git clone.
+    Call checkAndUpdateRepo, and then return the supplied table path itself.
+
+    If use_subdirs=True, assume that the cmor_table_path is a directory containing 
+    read-only subidrectories for the different versions of the tables (as fetched 
+    using esgfetchtables).  Returns the relevant subdirectory after checking that 
+    it exists.
+    """
+
+    if use_subdirs:
+        path = os.path.join(cmor_table_path, ds_version)
+        if not os.path.isdir(path):
+            raise ESGPublishError('tables directory {} does not exist'.format(path))
+        return path
+    else:
+        checkAndUpdateRepo(cmor_table_path, ds_version)
+        return cmor_table_path
+
+
+def checkedRun(command):
+    """
+    Run a command and check that it returns 0 status.
+    """
+    status = os.system(command)
+    if status != 0:
+        raise ESGPublishError(('command {} failed with status {}'
+                               ).format(command, status))
+
+
 def checkAndUpdateRepo(cmor_table_path, ds_version):
     """
         Checks for a file written to a predefined location.  if not present or too old, will pull the repo based on the input path argument and update the timestamp.
@@ -1144,9 +1178,8 @@ def checkAndUpdateRepo(cmor_table_path, ds_version):
             # Go into CMOR table path
             # Git fetch CMOR table repo
             # Go back to previous working directory
-            os.system('pushd {} >/dev/null ; '
-                      'git fetch --quiet ; '
-                      'popd >/dev/null'.format(cmor_table_path))
+            checkedRun(('cd {} && git fetch --quiet'
+                        ).format(cmor_table_path))
             # Update local timestamp
             f = open(UPDATE_TIMESTAMP, "w")
             f.write("CMOR table updated at {}".format(time()))
@@ -1161,10 +1194,8 @@ def checkAndUpdateRepo(cmor_table_path, ds_version):
         # Stash any changes from previous checkout 
         # Checkout to the appropriate CMOR table tag
         # Go back to previous working directory
-        os.system('pushd {} >/dev/null ; '
-                  'git stash --quiet ;'
-                  'git checkout {}  --quiet ; '
-                  'popd >/dev/null'.format(cmor_table_path, ds_version))
+        checkedRun(('cd {} && git stash --quiet && git checkout {} --quiet'
+                    ).format(cmor_table_path, ds_version))
         # Update local timestamp
         f = open(UPDATE_TIMESTAMP, "w")
         f.write("CMOR table updated at {}".format(time()))
@@ -1180,9 +1211,8 @@ def checkAndUpdateRepo(cmor_table_path, ds_version):
             # PrePARE requires to have the most up to date CMIP6 CV.
             # Update CMIP6_CV.json from master branch.
             # Go back to previous working directory
-            os.system('pushd {} >/dev/null ; '
-                      'git checkout master CMIP6_CV.json --quiet ; '
-                      'popd >/dev/null'.format(cmor_table_path))
+            checkedRun(('cd {} && git checkout master CMIP6_CV.json --quiet'
+                        ).format(cmor_table_path))
             debug("CMIP6 CV updated from master")
         except Exception as e:
             raise ESGPublishError("Master branch does not exists or CMIP6_CV.json not found or other error.  Please contact support" % ds_version)


### PR DESCRIPTION
1) Add option `force_validation` in `[config:<project>]` section, to force CMOR even if dataset is replica or has already passed CMOR.  (Default=False.)

2) Add option `cmor_table_subdirs` in `[config:<project>]` section, to treat the specified `cmor_table_path` as a directory containing (read-only) subdirectories for each table version.  These should be fetched using `esgfetchtables` (in esgprep).  If set to False (the default), the existing behaviour is retained, where the `cmor_table_path` points to a git clone.

3) When using a git clone (`cmor_table_subdirs=False`), check the return status of 'git' commands, and raise an exception if they fail.