### PR TITLE
Use [DEFAULT] section of esg.ini file for logging related vars

### DIFF
--- a/src/python/esgcet/esgcet/publish/wrappers.py
+++ b/src/python/esgcet/esgcet/publish/wrappers.py
@@ -22,7 +22,7 @@ def initdb(init_file=None, echoSql=False, log_filename=None):
     config = loadConfig(init_file)
     if dbengine is None:
         dbengine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=dbengine, log_filename=log_filename)
+    initLogging('DEFAULT', override_sa=dbengine, log_filename=log_filename)
     Session = sessionmaker(bind=dbengine, autoflush=True, autocommit=False)
     return config, Session
 

--- a/src/python/esgcet/esgcet/ui/extraction_controls.py
+++ b/src/python/esgcet/esgcet/ui/extraction_controls.py
@@ -28,7 +28,7 @@ def call_sessionmaker( root ):
     # Load the configuration and set up a database connection
     config = loadConfig(init_file)
     root.engine = create_engine(config.getdburl('extract'), echo=root.echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=root.engine)
+    initLogging('DEFAULT', override_sa=root.engine)
     Session = sessionmaker(bind=root.engine, autoflush=True, autocommit=False)
 
     # Register project handlers

--- a/src/python/esgcet/scripts/esgadd_facetvalues
+++ b/src/python/esgcet/scripts/esgadd_facetvalues
@@ -440,7 +440,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir)
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine, log_filename=log_filename)
+    initLogging('DEFAULT', override_sa=engine, log_filename=log_filename)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     # Register project handlers

--- a/src/python/esgcet/scripts/esgcopy_files
+++ b/src/python/esgcet/scripts/esgcopy_files
@@ -345,7 +345,7 @@ def main(argv):
 
     config = loadConfig(None)
     engine = create_engine(config.get('extract', 'replica_dburl'), echo=False, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
     registerHandlers()
     handler = getHandlerByName(project, None, Session)

--- a/src/python/esgcet/scripts/esgfind_excludes
+++ b/src/python/esgcet/scripts/esgfind_excludes
@@ -75,7 +75,7 @@ def main(argv):
     config = loadConfig(init_dir)
     dburl = config.getdburl('extract')
     engine = create_engine(config.getdburl('extract'), echo=False, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     project_init_file = os.path.join(init_dir, 'esg.%s.ini'%project_name)

--- a/src/python/esgcet/scripts/esglist_datasets
+++ b/src/python/esgcet/scripts/esglist_datasets
@@ -119,7 +119,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir)
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     # Register project handlers

--- a/src/python/esgcet/scripts/esglist_files
+++ b/src/python/esgcet/scripts/esglist_files
@@ -80,7 +80,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir)
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
     session = Session()
 

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -581,7 +581,7 @@ def main(argv):
 
     # set up a database connection
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine, log_filename=log_filename)
+    initLogging('DEFAULT', override_sa=engine, log_filename=log_filename)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     if threddsReinit:

--- a/src/python/esgcet/scripts/esgscan_directory
+++ b/src/python/esgcet/scripts/esgscan_directory
@@ -227,7 +227,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_file)
     engine = create_engine(config.getdburl('extract'), echo=False, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     # Register project handlers

--- a/src/python/esgcet/scripts/esgsetup
+++ b/src/python/esgcet/scripts/esgsetup
@@ -876,7 +876,7 @@ def main(argv):
 
             config = loadConfig(configdir, load_projects=False)
             engine = create_engine(config.getdburl('extract'), echo=False, pool_recycle=3600)
-            initLogging('extract', override_sa=engine)
+            initLogging('DEFAULT', override_sa=engine)
             Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
             updateThreddsMasterCatalog(Session)

--- a/src/python/esgcet/scripts/esgtest_publish
+++ b/src/python/esgcet/scripts/esgtest_publish
@@ -171,7 +171,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir, project_name)
     engine = create_engine(config.getdburl('extract'), pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
     session = Session()
 

--- a/src/python/esgcet/scripts/esgunpublish
+++ b/src/python/esgcet/scripts/esgunpublish
@@ -271,7 +271,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir)
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine, log_filename=log_filename)
+    initLogging('DEFAULT', override_sa=engine, log_filename=log_filename)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
 
     if config is None:

--- a/src/python/esgcet/scripts/esgupdate_metadata
+++ b/src/python/esgcet/scripts/esgupdate_metadata
@@ -74,7 +74,7 @@ def main(argv):
     # Load the configuration and set up a database connection
     config = loadConfig(init_dir)
     engine = create_engine(config.getdburl('extract'), echo=echoSql, pool_recycle=3600)
-    initLogging('extract', override_sa=engine)
+    initLogging('DEFAULT', override_sa=engine)
     Session = sessionmaker(bind=engine, autoflush=True, autocommit=False)
     session = Session()
 


### PR DESCRIPTION
Use `[DEFAULT]` instead of `[extract]` section of esg.ini file for logging-related variables for most commands.

(It looks like a line of code, which uses 'extract', was copied from esgextract to the other scripts.
This commit leaves it as 'extract' in esgextract and changes it in everything else.)