### PR TITLE
option to allow deterministic THREDDS catalog paths

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -107,6 +107,7 @@ sections. This file will be set up during the ESGF installation process.
                     OpenDAP    | /thredds/dodsC/               | OpenDAPServer | fileservice
                     Globus     | globus:#DEFAULTENDPOINTNAME#/ | Globus        | fileservice
             thredds_master_catalog_name = Earth System Grid catalog
+            thredds_use_numbered_directories = True
             thredds_max_catalogs_per_directory = 500
             thredds_offline_services =
                     SRM | srm://<fqdn>:6288/srm/v2/server?SFN=/archive.sample.gov | HRMatPCMDI

--- a/src/python/esgcet/esgcet/config/etc/template.ini
+++ b/src/python/esgcet/esgcet/config/etc/template.ini
@@ -112,6 +112,7 @@ thredds_password = changeme
 #   thredds_root = top level directory. An absolute path, not containing any substitution patterns.
 #   thredds_url = URL of the top-level THREDDS directory
 #   thredds_catalog_basename = basename of the catalog. Should contain the patterns %(dataset_id)s and %(version)s, and have extension .xml
+#   thredds_use_numbered_directories = whether to use numbered catalog subdirectories; default=True, but if false, bases subdirectory tree on DRS
 #   thredds_max_catalogs_per_directory = max number of catalogs in a subdirectory
 #   thredds_master_catalog_name = description of the TDS master catalog
 #
@@ -125,6 +126,7 @@ thredds_root = /esg/content/thredds/esgcet
 thredds_url = http://yourhost/thredds/catalog/esgcet
 
 thredds_catalog_basename = %(dataset_id)s.v%(version)s.xml
+thredds_use_numbered_directories = True
 thredds_max_catalogs_per_directory = 500
 thredds_master_catalog_name = Earth System Grid catalog
 thredds_root_catalog_name = Earth System Root catalog


### PR DESCRIPTION
Work between European centres regarding a load-balanced arrangement for CDS is going to require certain data nodes to have deterministic paths for the THREDDS catalogues, so that the same dataset can be published independently in multiple sites and have the local part of the URL be the same at each site.  This means adding an option to avoid the numbered subdirectories, which cannot be predicted.

This pull request adds a (non-default) functionality to allow the THREDDS catalogue location to be based on the dataset name, for example (relative to the THREDDS content root):

`esgcet/specs/output/KNMI/EC-EARTH2/seaIceInit/S19381101/mon/ocean/Omon/msftmyz/r10i1p1/specs.output.KNMI.EC-EARTH2.seaIceInit.S19381101.mon.ocean.Omon.msftmyz.r10i1p1.v1.xml`

in place of something like:

`esgcet/43/specs.output.KNMI.EC-EARTH2.seaIceInit.S19381101.mon.ocean.Omon.msftmyz.r10i1p1.v1.xml`

This new behaviour is switched on by setting `thredds_use_numbered_directories=False` in the `esg.ini` file (in which case any `thredds_max_catalogs_per_directory` setting is ignored). If the `thredds_use_numbered_directories` is not specified in the ini file, then it defaults to `True`, which is the existing behaviour.

Any subdirectories required are created when needed.  (The `esgunpublish` command does not bother to remove empty directories.  This could be added later if important.)

Existing functionality is to reuse any existing catalogue location stored in the database if a dataset is republished.  This functionality is retained.  So if the `thredds_use_numbered_directories` setting in the ini file is changed, then the change will not get reflected in the catalog location simply by rerunning `esgpublish ... --thredds`; the catalogue must first be removed using `esgunpublish`.

The changes have been tested, including publication of a few datasets through all the stages, searching and downloading data, and unpublication.

They also include some refactoring to reduce the length of the `generateThreddsOutputPath` function.

Some further considerations regarding the choice of directory name:

* The subdirectory path is based on the full DRS (rather than for example the first 5 elements), because it cannot be predicted in advance how deep would be necessary in order to fulfil the goal of avoiding a large number of files per directory, even though this is at the expense of having rather deep subdirectories.  An alternative strategy of using a hash was considered, but it could lead to too many directories at the top level, which would constitute a similar problem.

* The maximum length of the `location` column of the `catalog` table in the database is currently 255 characters.  The length will increase somewhat when using this new scheme, so I investigated this concern.  On the data node at CEDA (with 50k datasets spanning a number of projects), the longest location name of any dataset was 113 characters (a non-federated `esacci` dataset), which would become 197 characters in the new scheme.  The longest name for CMIP5 was 95 characters, which would become 172 characters.  These are relatively long but I believe they still leave adequate margin for the unexpected within the existing db schema.