### PR TITLE
Process map files in consistent order

### DIFF
--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -321,6 +321,8 @@ def yield_parsed_mapfiles(mapfileDir):
     yields (dmap, extraFields) for each valid mapfile found under starting directory
     """
     for root, dirs, files in os.walk(mapfileDir, followlinks=True):
+        dirs.sort()
+        files.sort()
         for mapfile in files:
             try:
                 dmap, extraFields = readDatasetMap(os.path.join(root, mapfile), parse_extra_fields=True)


### PR DESCRIPTION
At line 654 the list of dataset names and versions from a single map
file are sorted.  However, since the `esgmapfile` tool generates a
separate map file for each unique dataset and version by default [1],
this won't have any effect in sorting multiple versions of a given
dataset.  Instead the sort has to occur when walking the map file tree
so that map files with the same base filename (ie. dataset ID) but
different versions are ingested in the correct version order.  Given
that `os.walk()` uses `readdir()` the results aren't guaranteed to
be in any specific order and therefore need to be explicitly sorted.

[1] https://github.com/ESGF/esgf-prepare/blob/v2.9.3/esgprep/esgmapfile.py#L80