### PR TITLE
Fix retrieval of hessian cert location

### DIFF
--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -1234,7 +1234,7 @@ def checkAndUpdateRepo(cmor_table_path, ds_version):
 
 def getServiceCertsLoc():            
     try:
-        service_certs_location =  config.get('DEFAULT', 'hessian_service_certs_location')
+        service_certs_location =  getConfig().get('DEFAULT', 'hessian_service_certs_location')
 
     except:
         home = os.environ.get("HOME")


### PR DESCRIPTION
Fixes #133.

The reason `$HOME/.globus/certificates` is always returned is because the bare `except` catches the `NameError` for `config` not being defined.

Ideally, the bare `except` should be replaced with a more specific `except` catching only the exception(s) that are raised when a config item is missing.