### PR TITLE
move validateFile to validate all files

### DIFF
--- a/src/python/esgcet/esgcet/config/project.py
+++ b/src/python/esgcet/esgcet/config/project.py
@@ -147,7 +147,6 @@ class ProjectHandler(object):
                 fileobj = self.openPath(path)
             except:
                 raise ESGPublishError('Error opening %s. Is the data offline?'%path)
-            self.validateFile(fileobj)
             fileobj.close()
 
         self.validate = (validate in [None, True])

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -850,6 +850,9 @@ def iterateOverDatasets(projectName, dmap, directoryMap, datasetNames, Session, 
            else:
               testProgress1[2] = (100./ct)*iloop + (100./ct)
 
+        for path in fileiter:
+            fileobj = handler.openPath(path)
+            handler.validateFile(fileobj)
 
         dataset = extractFromDataset(datasetName, fileiter, Session, handler, cfHandler, aggregateDimensionName=aggregateDimension,
                                      offline=offline, operation=operation, progressCallback=testProgress1, perVariable=perVariable,


### PR DESCRIPTION
Moves from the handler base class in .project to utility where we can iterate over the files prior to extraction