### PR TITLE
add option to skip PrePARE

### DIFF
--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -50,8 +50,17 @@ class CMIP6Handler(BasicHandler):
         data_specs_version = config.get(project_config_section, "data_specs_version", default="master")
         cmor_table_path = config.get(project_config_section, "cmor_table_path", default=DEFAULT_CMOR_TABLE_PATH)
         force_validation = config.getboolean(project_config_section, "force_validation", default=False)
+        skip_validation = config.getboolean(project_config_section, "skip_validation", default=False)
         cmor_table_subdirs = config.getboolean(project_config_section, "cmor_table_subdirs", default=False)
 
+        if skip_validation:
+
+            if force_validation:
+                raise ESGPublishError("skip_validation and force_validation both enabled in config")                
+
+            info("skipping PrePARE because skip_validation set in config")
+            return
+        
         if not force_validation:
 
             if self.replica:


### PR DESCRIPTION
Support a configuration option in CMIP6 handler (`skip_validation` in `[config:cmip6]` section of `esg.ini`), to skip PrePARE.

This is to allow sites to optimise by skipping PrePARE in the publisher where they are already running PrePARE separately outside of the publisher.

We do not need to advertise this option if there is any concern about it being abused for purpose of completely avoiding running PrePARE.