### PR TITLE
Refactor normalize_path to respect data roots from ini

### DIFF
--- a/pkg/esgcet/mapfile.py
+++ b/pkg/esgcet/mapfile.py
@@ -7,25 +7,14 @@ log = logger.Logger()
 
 class ESGPubMapConv:
 
-    def __init__(self, mapfilename, project=None, normalize=False, silent=False):
+    def __init__(self, mapfilename, project=None, silent=False):
 
         self.mapfilename = mapfilename
         self.project = project
-        self.normalize = normalize
         self.map_data_arr = []
         self.map_json = {}
         self.silent = silent
         self.publog = log.return_logger('Mapfile Conversion', silent=silent)
-
-    def normalize_path(self, path, project=None):
-        if project is None:
-            project = self.project
-        pparts = path.split('/')
-        idx = pparts.index(project)
-        if idx < 0:
-            raise(BaseException("Incorrect Project in File Path!"))
-        proj_root = '/'.join(pparts[0:idx])
-        return('/'.join(pparts[idx:]), proj_root)
 
     def parse_map(self, mountpoints=None):
         """  """
@@ -33,8 +22,6 @@ class ESGPubMapConv:
         for line in self.map_data:
 
             parts = line.rstrip().split(' | ')
-            if self.normalize:
-                parts[1] = self.normalize_path(parts[1])
             if mountpoints and self.project:
                 mapstr = parts[1]
                 root = mapstr.split(self.project)[0][:-1]
@@ -75,20 +62,6 @@ class ESGPubMapConv:
             self.map_json = json.load(open(self.mapfilename))
         except:
             self.publog.error("Could not open json data {}".format(self.mapfilename))
-
-    def map_entry(self, project, fs_root):
-        norm_path = self.normalize_path(self.map_json['file'])
-        abs_path = "{}/{}".format(fs_root, norm_path)
-        outarr = []
-
-        outarr.append(self.map_json['id'])
-        outarr.append(abs_path)
-        outarr.append(self.map_json['size'])
-        for x in self.map_json:
-            if not x in ['id', 'file', 'size']:
-                outarr.append("{}={}".format(x,self.map_json[x]))
-        return ' | '.join(outarr)
-
 
     def mapfilerun(self, mountpoints=None):
 

--- a/pkg/esgcet/mk_dataset.py
+++ b/pkg/esgcet/mk_dataset.py
@@ -202,7 +202,7 @@ class ESGPubMakeDataset:
             if kn not in ("id", "file"):
                 ret[kn] = mapdata[kn]
 
-        rel_path, proj_root = self.mapconv.normalize_path(fullfn, self.first_val)
+        rel_path, proj_root = self.normalize_path(fullfn, self.data_roots)
 
         if not proj_root in self.data_roots:
 
@@ -426,3 +426,22 @@ class ESGPubMakeDataset:
         self.dataset["access"] = access
         ret.append(self.dataset)
         return ret
+
+    @staticmethod
+    def normalize_path(path, data_roots):
+
+        proj_root = None
+
+        # Check each data root to see if it matches the provided path
+        for data_root, _ in data_roots.items():
+
+            path_match = "{}/".format(data_root.rstrip("/"))
+            if path.startswith(path_match):
+
+                rel_path = path[len(path_match):]
+                proj_root = data_root.rstrip("/")
+
+        if not proj_root:
+            raise(BaseException("File Path does not match any data roots!"))
+
+        return rel_path, proj_root


### PR DESCRIPTION
Changes based on review of code by @alaniwi and I. Addresses the issue of normalize_path method not respecting data roots from the ini file, which may be important for generating the correct paths for search.

e.g. In the old method, the path `/alldata/cordex/data/cordex/files/somefile.nc`, with data roots `{"/alldata/cordex/data": "esg_cordex"}`
would be normalized as `("cordex/data/cordex/files/somefile.nc", "/alldata")`, rather than `("cordex/files/somefile.nc", "/alldata/cordex/data")`