### PR TITLE
Change use of skip_prepare and add force_prepare

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v5.1.0-b8
+---------
+* Change skip_prepare semantics (applies to CMIP6 *non*-replica publishing to bypass PrePARE -
+  should only be used where data has already passed PrePARE outside of the publisher)
+
 v5.1.0-b7
 ---------
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -3,8 +3,14 @@ Release Notes
 
 v5.1.0-b8
 ---------
-* Change skip_prepare semantics (applies to CMIP6 *non*-replica publishing to bypass PrePARE -
-  should only be used where data has already passed PrePARE outside of the publisher)
+* Change skip_prepare semantics and add force_prepare option so that they behave like
+  skip_validation and force_validation in the legacy publisher:
+   - default behavior is to run PrePARE for non-replica but not for replica
+   - with skip_prepare=True, PrePARE is *never* run
+   - with force_prepare=True, PrePARE is *always* run
+   - if both are set, the publisher reports an error and exits
+  (skip_prepare=True should only be used where the data node manager has already ensured
+  that the data has passed PrePARE outside of the publisher)
 
 v5.1.0-b7
 ---------

--- a/pkg/esgcet/args.py
+++ b/pkg/esgcet/args.py
@@ -164,12 +164,21 @@ class PublisherArgs:
             dtn = "none"
 
         skip_prepare = False
-
         try:
             skip_prep_str = config['user']['skip_prepare'].lower()
             skip_prepare = (skip_prep_str in ["true", "yes"])
         except:
             pass
+        force_prepare = False
+        try:
+            force_prep_str = config['user']['force_prepare'].lower()
+            force_prepare = (force_prep_str in ["true", "yes"])
+        except:
+            pass
+        if skip_prepare and force_prepare:
+            publog.error("PrePARE simultaneously skipped and forced.")
+            exit(1)
+
         if pub.set_replica and pub.no_replica:
             publog.error("Replica publication simultaneously set and disabled.")
             exit(1)
@@ -244,7 +253,8 @@ class PublisherArgs:
                    "autoc_command": autoc_command, "index_node": index_node, "data_node": data_node,
                    "data_roots": data_roots, "globus": globus, "dtn": dtn, "replica": replica,
                    "json_file": json_file, "test": test, "user_project_config": proj_config, "verify": verify,
-                   "auth": auth, "skip_prepare": skip_prepare, "non_nc": non_nc, "mountpoints": mountpoints}
+                   "auth": auth, "skip_prepare": skip_prepare, "force_prepare": force_prepare,
+                   "non_nc": non_nc, "mountpoints": mountpoints}
 
         if project and "none" not in project:
             argdict["proj"] = project

--- a/pkg/esgcet/cmip6.py
+++ b/pkg/esgcet/cmip6.py
@@ -23,7 +23,7 @@ class cmip6(GenericPublisher):
         self.cmor_tables = os.path.expanduser(argdict["cmor_tables"])
         self.test = argdict["test"]
         if self.replica:
-            self.skip_prepare = True
+            self.skip_prepare = not argdict["force_prepare"]
         else:
             self.skip_prepare = argdict["skip_prepare"]
         self.publog = log.return_logger('CMIP6', self.silent, self.verbose)

--- a/pkg/esgcet/cmip6.py
+++ b/pkg/esgcet/cmip6.py
@@ -23,9 +23,9 @@ class cmip6(GenericPublisher):
         self.cmor_tables = os.path.expanduser(argdict["cmor_tables"])
         self.test = argdict["test"]
         if self.replica:
-            self.skip_prepare= argdict["skip_prepare"]
+            self.skip_prepare = True
         else:
-            self.skip_prepare = False
+            self.skip_prepare = argdict["skip_prepare"]
         self.publog = log.return_logger('CMIP6', self.silent, self.verbose)
 
     def prepare_internal(self, json_map, cmor_tables):


### PR DESCRIPTION
The `skip_prepare` setting is currently used to skip PrePARE for replicas but it is always enforced for the primary copy. This PR changes the behavior so that it applies to **non**-replicas, and also adds a `force_prepare` option for replicas, in order to make it more analogous to the `skip_validation` and `force_validation` options used in the existing publisher.

See the changes to the release notes file below for more info.

(See [here](https://github.com/ESGF/esg-publisher/blob/master/src/python/esgcet/esgcet/config/cmip6_handler.py#L52-L79) for the existing behavior.  NB the existing `force_validation` also overrides the check as to whether a suitable `cmor_version` attribute already exists in the file metadata, but that check does not seem to exist in the refactored publisher.)

We have a use case for skipping PrePARE at CEDA, because we have a workflow where we are always running PrePARE as a separate step (outside of the publisher) before we even ingest the data into our archive, so we do not want to duplicate this inside the publisher (which we run after data ingestion).

Currently the option is not documented. If it is later documented, then we should ensure that data node managers' responsibilities are clear and that `skip_prepare` should not be used as a means to publish data that fails validation.