### PR TITLE
CMIP6 clone fixes

### DIFF
--- a/pkg/esgcet/cmip6.py
+++ b/pkg/esgcet/cmip6.py
@@ -48,8 +48,9 @@ class cmip6(GenericPublisher):
 
     def pid(self, out_json_data):
       
-        pid = ESGPubPidCite(out_json_data, self.pid_creds, self.data_node, test=self.test, silent=self.silent, verbose=self.verbose)
-        
+        pid = ESGPubPidCite(out_json_data, self.pid_creds, self.data_node, test=self.test,
+                            silent=self.silent, verbose=self.verbose,
+                            project_family='CMIP6')
         if self.cmor_tables:
             check = FieldCheck(self.cmor_tables, silent=self.silent)
             try:

--- a/pkg/esgcet/mk_dataset.py
+++ b/pkg/esgcet/mk_dataset.py
@@ -27,14 +27,17 @@ class ESGPubMakeDataset:
             self.DRS = DRS[cloneproj]
             if cloneproj in CONST_ATTR:
                 self.CONST_ATTR = CONST_ATTR[cloneproj]
-        if self.user_project and project in self.user_project:
+            else:
+                self.CONST_ATTR = {}
+            if 'CONST_ATTR' in self.user_project[project]:
+                self.CONST_ATTR.update(self.user_project[project]['CONST_ATTR'])
+        elif self.user_project and project in self.user_project:
             if 'DRS' in self.user_project[project]:
                 self.DRS = self.user_project[project]['DRS']
             if 'CONST_ATTR' in self.user_project[project]:
                 self.CONST_ATTR = self.user_project[project]['CONST_ATTR']
         else:
             raise (BaseException(f"Error: Project {project} Data Record Syntax (DRS) not defined. Define in esg.ini"))
-        #print(f"CONST ATTR: {self.CONST_ATTR}")
 
     def __init__(self, data_node, index_node, replica, globus, data_roots, dtn, silent=False, verbose=False, limit_exceeded=False, user_project=None):
         self.silent = silent
@@ -124,7 +127,6 @@ class ESGPubMakeDataset:
         self.global_attr_mapped(projkey, scandata)
         self.assign_dset_values(master_id, version)
         self.const_attr()
-        #print(f"project: {self.dataset['project']}")
         if not 'project' in self.dataset:
             self.dataset['project'] = priorkey
 

--- a/pkg/esgcet/pid_cite_pub.py
+++ b/pkg/esgcet/pid_cite_pub.py
@@ -16,7 +16,8 @@ def get_url(arr):
 class ESGPubPidCite(object):
     """ for PID services wraps calls to obtain a PID, add to records and generate citiation metadata """
 
-    def __init__(self, ds_recs, pid_creds, data_node, test=False, silent=False, verbose=False, pid_prefix=PID_PREFIX):
+    def __init__(self, ds_recs, pid_creds, data_node, test=False, silent=False, verbose=False, pid_prefix=PID_PREFIX,
+                 project_family=None):
         """ Constructor
             ds_rec - a dataset record (dictionary/json)
             pid_creds - credentials typically loaded from config file, contains PID server, password, etc.
@@ -28,6 +29,7 @@ class ESGPubPidCite(object):
         self.verbose = verbose
         self.test_publication = test
         self.pid_prefix = pid_prefix
+        self.project_family = project_family
         self.data_node = data_node
         self.publog = log.return_logger('PID Citation', silent, verbose)
 
@@ -166,8 +168,9 @@ class ESGPubPidCite(object):
     def update_dataset(self, index):
 
         dset_rec = self.ds_records[index]
-        project = dset_rec['project'].lower()
-
+        # project is taken from the record metadata unless project_family is a truthy value
+        # (defaults to None, but might be e.g. 'CMIP6')
+        project = (self.project_family or dset_rec['project']).lower()
         # At present we only support the stock templates from CMIP6
         if not project in CITATION_URLS:
             return


### PR DESCRIPTION
@sashakames Here is a pull request for a couple of fixes to the clone project code, which I believe that I have tested pretty carefully, both with CMIP6 and with PRIMAVERA.  It addresses two issues, which you'll see in the separate commits.

In https://github.com/ESGF/esg-publisher/commit/58d0aaf08b1a1abf430e499fb32509b946d78ff5, I undo your change from `elif` to `if`, which in fact broke CMIP6 publication (from recollection, it raised an exception), and went back to the strategy which I had mentioned previously, of merging the two `CONST_ATTR` dictionaries using `dict.update`.  This had in fact worked all along; the only reason why I thought it didn't was that when I had tested it using CMIP6 data, I was inadvertently using a script that invoked the publisher with `--project primavera`.  Once this was corrected, it was fine.

In https://github.com/ESGF/esg-publisher/commit/0bee39bf91940fc1ddecfeee47b34980196fd6e8, I address an issue that although the above fix is necessary to have the correct project when publishing PRIMAVERA, it is not sufficient, because certain dataset metadata fields that are added in `pid_cite_pub.py` (namely `pid`, `citation_url`, `xlink`) do not get added because `project in CITATION_URLS` evaluates `False` when `project=='primavera'`, causing it to return without doing anything.  To avoid this, I add the concept of a "project family" such that whenever it is called from `cmip6.py`, the project will be set to `'cmip6'` for the purpose of this lookup, and the fields are added as they should be.

I have found the following during testing. To summarise: (a) I'm confident of no adverse effects on CMIP6, (b) PRIMAVERA appears basically working when it wasn't before, apart from a possible issue of citation URL, please see below.

 - CMIP6 dataset:
     - I get identical results when publishing using the HEAD of the `cmip6_clone_fixes` branch that this PR is from (in combination with your recommended contents of the ini file for setting up PRIMAVERA as a CMIP6 clone) as what I get from the HEAD of the `refactor-esgf` branch (in combination with our previous ini file), except for:
        - different (random?) sorting of metadata fields
        - you have added `model_cohort`
     - I find that there is an issue with the file download URLs at the PID service (not the ones in the ESGF Solr index itself), which I need to contact DKRZ about, but that this issue is the same for both of the setups mentioned above, so seems to be unrelated to the publisher changes

 - PRIMAVERA dataset
    -  Note that I could not previously publish with the refactored publisher, so my only comparison is with records previously published with the old publisher
    - Using the new publisher at the head of `cmip6_clone_fixes` with your suggested `cmip6_clone` line in the ini file, it is now possible to publish PRIMAVERA and have the CMIP6-like metadata fields added, and this includes `pid` etc
    - The PID record URL pointed to with `pid` is correct and leads to a valid record.
    - The further-info URL gives a 404 at the PID service, but this was also the case with the old publisher, so this issue is not related to the publisher changes
    - The citation URL is a newly added field compared to the old publisher, and the URL pointed to ([example](http://cera-www.dkrz.de/WDCC/meta/CMIP6/PRIMAVERA.primWP5.CNRM-CERFACS.CNRM-CM6-1.primWP5-amv-neg.r10i1p1f2.SIday.sitimefrac.gn.v20220922.json)) does not work.

So the only reservation in all this is the possibly wrong citation URL for PRIMAVERA.  Please can you check this.  My guess is that it is something that I should take up with DKRZ but that it is not a reason to delay in merging the pull request, but it is hard for me to be sure because I don't have any example with previously published PRIMAVERA datasets to compare it with.