### PR TITLE
Only call setup once.

### DIFF
--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -25,7 +25,18 @@ DEFAULT_ESGINI = '/esg/config/esgcet'
 
 make_config = True
 
+
+additional_requirements = []
 if make_config:
+    additional_requirements = [
+            "xarray",
+            "netcdf4",
+            "dask",
+            "pyyaml"
+]
+
+
+if True: # if __name__ == '__main__':
     setup(
         name = 'esgcet',
         version = VERSION,
@@ -37,11 +48,7 @@ if make_config:
             "requests",
              "esgfpid",
             "ESGConfigParser==1.0.0a1",
-            "xarray",
-            "netcdf4",
-            "dask",
-            "pyyaml"
-        ],
+        ] + additional_requirements,
         packages = find_packages(exclude=['ez_setup']),
         include_package_data = True,
         scripts = [
@@ -56,30 +63,3 @@ if make_config:
                                           'esgmigrate=esgcet.migratecmd:main',
                                           'esgunpublish=esgcet.esgunpublish:main']}
     )
-else:
-    setup(
-        name = 'esgcet',
-        version = VERSION,
-        description = 'ESGCET publication package',
-        author = 'Sasha Ames',
-        author_email = 'ames4@llnl.gov',
-        url = 'http://esgf.llnl.gov',
-        install_requires = [
-            "requests",
-             "esgfpid",
-            "ESGConfigParser==1.0.0a1"
-        ],
-        packages = find_packages(exclude=['ez_setup']),
-        include_package_data = True,
-        scripts = [
-        ],
-        zip_safe = False,                   # Migration repository must be a directory
-        entry_points={'console_scripts': ['esgpidcitepub=esgcet.esgpidcitepub:main',
-                                          'esgmkpubrec=esgcet.esgmkpubrec:main',
-                                          'esgindexpub=esgcet.esgindexpub:main',
-                                          'esgpublish=esgcet.pub_internal:main',
-                                          'esgupdate=esgcet.esgupdate:main',
-                                          'esgmapconv=esgcet.esgmapconv:main'
-                                          'esgmigrate=esgcet.migratecmd:main',
-                                          'esgunpublish=esgcet.esgunpublish:main']}
-        )


### PR DESCRIPTION
Idea is to simplify the 'setup.py' by just using an additional list of to-be-added dependencies in case the 'make_config' is to be done. Call to `setup()` is made only once.

Not sure what is really needed. It's just an example.
