### PR TITLE
Python 3.6 conversion

### DIFF
--- a/src/python/esgcet/mk_dataset_xarray.py
+++ b/src/python/esgcet/mk_dataset_xarray.py
@@ -2,6 +2,7 @@ import xarray, netCDF4
 from esgcet.handler_base import ESGPubHandlerBase
 import os.path
 import numpy as np
+import cftime
 
 class ESGPubXArrayHandler(ESGPubHandlerBase):
 
@@ -42,6 +43,8 @@ class ESGPubXArrayHandler(ESGPubHandlerBase):
             x = str(timeval)
             idx = x.index('.')
             return x[:idx] + 'Z'
+        elif isinstance(timeval.item(), cftime.DatetimeNoLeap):
+           return str(timeval).replace(" ", "T") + "Z"
         else:
             return timeval.item().isoformat() + "Z"
         


### PR DESCRIPTION
Fix syntax error related to creation of date when the type is cftime.DatetimeNoLeap