### PR TITLE
tweak bad XML in payload, in particular using & -> &amp;

### DIFF
--- a/src/python/esgcet/pub_client.py
+++ b/src/python/esgcet/pub_client.py
@@ -1,5 +1,6 @@
 import requests
 import esgcet.logger as logger
+from esgcet.xmlfix import fixup_xml
 
 log = logger.ESGPubLogger()
 
@@ -33,6 +34,12 @@ class publisherClient(object):
             url - the url
             data - the post data payload
         """
+        new_data = fixup_xml(data)
+        if self.verbose and data != new_data:
+            self.publog.info(f'payload before tweaking XML: {data}')
+            self.publog.info(f'payload after tweaking XML: {new_data}')
+        data = new_data
+        
         if self.use_cert:
             resp = requests.post(url, data=data, cert=(self.certFile, self.keyFile), verify=self.verify, allow_redirects=True)
         else:

--- a/src/python/esgcet/xmlfix.py
+++ b/src/python/esgcet/xmlfix.py
@@ -1,0 +1,46 @@
+import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ParseError
+import re
+
+
+def is_parseable_xml(s):
+    try:
+        tree = ET.fromstring(s)
+        return True
+    except ParseError:
+        return False
+
+
+def fixup_xml(s):
+    """
+    apply known tweaks to ensure parseable XML
+    """
+    if is_parseable_xml(s):
+        return s
+
+    # replace & with &amp; -- first try to preserve anything that looks like an HTML entity,
+    # but if this doesn't work then just replace it unconditionally
+    if "&" in s:
+        s1 = re.sub("&(?![^\s]+;)", "&amp;", s)
+        if is_parseable_xml(s1):
+            s = s1
+        else:
+            s = s.replace('&', '&amp;')
+
+    # add any more fixes here...
+        
+    if is_parseable_xml(s):
+        return s
+    else:
+        raise Exception("Don't know a way to turn payload into parseable XML")
+    
+    
+if __name__ == '__main__':
+    for s in ('<doc><field name="foo">blah</field><field name="bar">blah &lt; blah</field></doc>',
+              '<doc><field name="foo">bl & ah</field><field name="bar">blah &lt; blah</field></doc>',
+              '<doc><field name="foo">bl & ah</field><field name="bar">blah &stuff; blah</field></doc>',
+              '<doc><field name="foo">nohope'):
+              print(s)
+              print(is_parseable_xml(s))
+              print(fixup_xml(s))
+              print()


### PR DESCRIPTION
input4MIPs data from UoM would not publish - it turns out that it was constructing invalid XML in the payload, containing an `&` sign found in the netCDF global attribute `source` which was not part of a valid entity (value contains the substring `"NOAA & AGAGE networks"`).  This commit will cause this to be changed to `&amp;`, while also trying to preserving any ampersands which are already part of HTML entities.  With this tweak, the data is now publishable.

@sashakames Note that I have forked from 5.2.4.  I attempted to fork from the HEAD of `v5.2.5-proj` but that seems to not be working at the moment.  I think that my changes are orthogonal to whatever you are working on there, and should be easily merged when needed.