### PR TITLE
Handle responses from STAC Transaction API correctly

### DIFF
--- a/src/python/esgcet/generic_pub.py
+++ b/src/python/esgcet/generic_pub.py
@@ -118,7 +118,7 @@ class BasePublisher(object):
                 "length": int(self.argdict["archive_path_length"]),
                 "archive_path": self.argdict["archive_path"],
             }
-        print(f"VERBOSE: {self.verbose}")
+
         # TODO: support solr and Globus using the globus_index argument
 
         if self.argdict.get("stac_config") or self.argdict.get("stac_api"):
@@ -134,8 +134,7 @@ class BasePublisher(object):
                 stac_item = sc.convert2stac(dataset_records)
                 rc = tc.publish(stac_item)
             except Exception as ex:
-                self.publog.error(f"Failed to publish to STAC Transaction API, possble Validation Error.")
-                self.publog.debug(str(ex))
+                self.publog.error(f"Failed to publish to STAC Transaction API: {ex}")
                 rc = False
 
         else:

--- a/src/python/esgcet/stac_client.py
+++ b/src/python/esgcet/stac_client.py
@@ -11,6 +11,8 @@ from globus_sdk import (
     GroupsClient,
     NativeAppAuthClient,
     RefreshTokenAuthorizer,
+    GlobusError,
+    NetworkError,
 )
 from globus_sdk.scopes import GroupsScopes
 
@@ -142,8 +144,14 @@ class GlobusTransactionClient:
                 f"/collections/{collection}/items", headers=headers, data=entry
             )
             self.publog.info(f"STAC Transaction API: {resp.text}")
+        except NetworkError as e:
+            self.publog.error(f"Failed to publish: {e}: {e.underlying_exception}")
+            return False
+        except GlobusError as e:
+            self.publog.error(f"Failed to publish: {e}")
+            return False
         except Exception as e:
-            self.publog.error(f"Failed to publish: Error {e}")
+            self.publog.error(f"Failed to publish: {e}")
             return False
         return True
 

--- a/src/python/esgcet/stac_client.py
+++ b/src/python/esgcet/stac_client.py
@@ -65,7 +65,7 @@ class GlobusTransactionClient:
             refresh_tokens=True,
         )
         authorize_url = self.auth_client.oauth2_get_authorize_url()
-        print("Please go to this URL and login: {0}".format(authorize_url))
+        print("\nPlease go to this URL and login: {0}".format(authorize_url))
         auth_code = input("Please enter the code here: ").strip()
         return self.auth_client.oauth2_exchange_code_for_tokens(auth_code)
 
@@ -83,10 +83,19 @@ class GlobusTransactionClient:
         self.groups_tokens = token_storage.get_token_data(
             GroupsClient.resource_server
         )
-
         self.transaction_tokens = token_storage.get_token_data(
             self.trans_client_id
         )
+
+        if not self.groups_tokens or not self.transaction_tokens:
+            response = self._do_login_flow()
+            token_storage.store_token_response(response)
+            self.groups_tokens = token_storage.get_token_data(
+                GroupsClient.resource_server
+            )
+            self.transaction_tokens = token_storage.get_token_data(
+                self.trans_client_id
+            )
 
         groups_authorizer = RefreshTokenAuthorizer(
             self.groups_tokens.refresh_token,
@@ -125,21 +134,17 @@ class GlobusTransactionClient:
             with open(f"{entry['id']}.json", "w") as f:
                 f.write(json.dumps(entry, indent=1))
 
-        if not self.dry_run:
+        if self.dry_run:
+            self.publog.info(f"Dry-run mode: Not publishing")
+            return True
+        try:
             resp = self.transaction_client.post(
                 f"/collections/{collection}/items", headers=headers, data=entry
             )
-            match resp.http_status:
-                case 201:
-                    self.publog.info(f"{resp.http_status}: Published")
-                case 202:
-                    self.publog.info(f"{resp.http_status}: Queued for publication")
-                case 400:
-                    self.publog.error(f"{resp.http_status}: Validation error")
-                    return False
-                case _:
-                    self.publog.error(f"Failed to publish: Error {resp.http_status}")
-                    return False
+            self.publog.info(f"STAC Transaction API: {resp.text}")
+        except Exception as e:
+            self.publog.error(f"Failed to publish: Error {e}")
+            return False
         return True
 
     def json_patch(self, collection, item_id, entry):
@@ -154,23 +159,19 @@ class GlobusTransactionClient:
             "User-Agent": f"esgf_publisher/{__version__}",
         }
         self.publog.debug(f"PATCH request {collection} {item_id} {entry}")
+
         if self.dry_run:
-            print("Not PATCHing (dry-run mode)")
+            self.publog.info("Not PATCHing (dry-run mode)")
             return
-        resp = self.transaction_client.patch(
-            f"/collections/{collection}/items/{item_id}", headers=headers, data=entry
-        )
-        if resp.http_status == 201:
-            print(resp.http_status)
-            print("Updated (JSON PATCH)")
-            return True
-        elif resp.http_status == 202:
-            print(resp.http_status)
-            print("Queued for update (JSON PATCH)")
-            return True
-        else:
-            print(f"Failed to update (JSON PATCH): Error {resp.http_status}")
+        try:
+            resp = self.transaction_client.patch(
+                f"/collections/{collection}/items/{item_id}", headers=headers, data=entry
+            )
+            self.publog.info(f"STAC Transaction API: {resp.text}")
+        except Exception as e:
+            self.publog.error(f"Failed to update: Error {e}")
             return False
+        return True
 
 
 class EGITransactionClient:

--- a/src/python/esgcet/stac_client.py
+++ b/src/python/esgcet/stac_client.py
@@ -176,8 +176,14 @@ class GlobusTransactionClient:
                 f"/collections/{collection}/items/{item_id}", headers=headers, data=entry
             )
             self.publog.info(f"STAC Transaction API: {resp.text}")
+        except NetworkError as e:
+            self.publog.error(f"Failed to update: {e}: {e.underlying_exception}")
+            return False
+        except GlobusError as e:
+            self.publog.error(f"Failed to update: {e}")
+            return False
         except Exception as e:
-            self.publog.error(f"Failed to update: Error {e}")
+            self.publog.error(f"Failed to update: {e}")
             return False
         return True
 


### PR DESCRIPTION
The PR fixes the following issues:

* When a user switches from the integration to the production STAC Transaction API (configured in esg.yml), corresponding refresh tokens cannot be found in ~/.esgf-publisher.json, causing an exception to be raised.
* Correctly catches and handles exceptions thrown by TransactionClient when the STAC Transaction API returns a 4xx or 5xx response, and displays the error message returned by the API.