### PR TITLE
Small fixes for cordex-cmip6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "dask[distributed]",
     "pyyaml",
     "cc-plugin-wcrp>=2.0.0",
-    "pathlib",
     "pystac_client",
     "kerchunk",
     "virtualizarr",

--- a/src/python/esgcet/pub_internal.py
+++ b/src/python/esgcet/pub_internal.py
@@ -76,7 +76,7 @@ class PubRunner:
 
                 proj = BasePublisher(argdict)
             elif (
-                project == "generic" or project == "cordex" or user_defined or project == "none"
+                project == "generic" or project == "cordex" or project == "cordex-cmip6" or user_defined or project == "none"
             ):
                 if project == "none" and not argdict["silent"]:
                     publog.info("Using default settings, project not specified.")

--- a/src/python/esgcet/settings.py
+++ b/src/python/esgcet/settings.py
@@ -216,8 +216,8 @@ GA = {
         "title", 
         "mip_era",
         "domain",
-    "project_id",
-    "version_realization_info",
+        "project_id",
+        "version_realization_info",
         "driving_institution_id",
         "source_type",
         "activity_id"
@@ -279,9 +279,9 @@ PID_CREDS = [
 ]
 
 PID_PREFIX = { 
- "cmip6" :  "21.14100" ,
- "cmip6plus" : "21.14100",
- "input4mips" : "21:14100",
+    "cmip6" :  "21.14100" ,
+    "cmip6plus" : "21.14100",
+    "input4mips" : "21:14100",
     "cordex-cmip6" : "21.14103" ,
     "mip-drs7" : "21.14107" ,
     # for testing use CMIP6,  need to be project-specific


### PR DESCRIPTION
Reopening of sashakames/esg-publisher#8 to change the target branch.


The first commit adds "cordex-cmip6" the Generic Publishers (overriden by a previous change).

The second commit fixes ESGF/esg-publisher#299.

The third is simple linting.