### PR TITLE
Fix cordex QA and antimeridian

### DIFF
--- a/src/python/esgcet/settings.py
+++ b/src/python/esgcet/settings.py
@@ -308,7 +308,7 @@ SET_REPLICA = False
 
 QAQC = {
     "cordex-cmip6": {
-        "test": ["wcrp_cordexcmip6:1.0"],
+        "test": ["wcrp_cordex_cmip6:1.0"],
         "criteria": "lenient",
         "include_checks": None,
         "skip_checks": None,

--- a/src/python/esgcet/stac_converter.py
+++ b/src/python/esgcet/stac_converter.py
@@ -201,6 +201,11 @@ class ESGSTACConverter:
         if namespace.startswith("cmip"):
             west_degrees -= 180
             east_degrees -= 180
+        else:  # STAC needs longitude in range [-180, 180], but CF might use [0, 360]
+            if west_degrees > 180:
+                west_degrees -= 180
+            if east_degrees > 180:
+                east_degrees -= 180
 
         dt_start = dataset_doc.get("datetime_start", None)
         dt_end = dataset_doc.get("datetime_end", None)


### PR DESCRIPTION
Hi!

This fixes a typo in the QA/QC name for cordex, an underscore was missing!

Also, CF conventions do not force longitudes to use the [-180, 180] range, but STAC does. I think we can expect publishable datasets to use one of [0, 360] or [-180, 180], so this PR adds a simple test to transform bounds accordingly when creating the STAC Post call. 

There already was something similar for CMIP projects, I didn't touch it, but rather added my logic for the _other_ cases. CORDEX falls in these. Specifically, my North American data crosses the antimeridian (-180°) in its northwest corner and so the QA/QC requires that longitudes in the file be given in the 0-360 range.

-- 

I tested it and was able to upload the `CORDEX-CMIP6.DD.NAM-12.OURANOS.ERA5.evaluation.r1i1p1f1.CRCM5-SN.v1-r1.3hr.zmla.v20260318` dataset to the `transaction-int.west.esgf.io` node, but there's seem to be an issue, because I can't find it when querying `https://discovery-int.west.esgf.io/` with pystac.

I did:
```python3
from pystac_client import Client
catalog = Client.open('https://discovery-int.west.esgf.io/')
for i in catalog.get_all_items():
    if 'OURANOS' in i.id:
        print(i.id)
```
I see other datasets I uploaded before (with 5.4.3), but not the new one.
Some commands with the client give me "InternalError", but I'm not sure if it's because I don't know how to use them...