### PR TITLE
unquote URLs for ALL files (not only the last one)

### DIFF
--- a/src/python/esgcet/mk_dataset.py
+++ b/src/python/esgcet/mk_dataset.py
@@ -451,15 +451,11 @@ class ESGPubMakeDataset:
                 continue
             scanrec = scandata[fullpath]
             file_rec = self.get_file(maprec, scanrec)
+            file_rec["url"] = [unquote(x) for x in file_rec["url"] if x]
             last_file = file_rec
             sz += file_rec["size"]
             ret.append(file_rec)
 
-        lst = []
-        for x in last_file["url"]:
-            if x:
-                lst.append(unquote(x))
-        last_file["url"] = lst
         access = [x.split("|")[2] for x in last_file["url"]]
 
         return ret, sz, access


### PR DESCRIPTION
When publishing multiple files, only the last one would appear as an asset.

This is because only the last URL is unescaped, and because of a later test that evaluates `False` if the URL is escaped:
https://github.com/ESGF/esg-publisher/blob/27da03ac8d8dc13a0958e9d93842aac9f8bbc123/src/python/esgcet/stac_converter.py#L167

I was seeing this (see near the end of the line):
```
(Pdb) url0 = ret[0]["url"]
(Pdb) url1 = ret[1]["url"]
(Pdb) url0
['https://esgf.ceda.ac.uk/data/esg_cmip7/MIP-DRS7/CMIP7/CMIP/UKNCSP/UKESM1-3-LL/esm-hist/r1i1p1f1/glb/mon/tas/tavg-h2m-hxy-u/g110/v20260814/tas_tavg-h2m-hxy-u_mon_glb_g110_UKESM1-3-LL_esm-hist_r1i1p1f1_195001-202112.nc%7Capplication/netcdf%7CHTTPServer']
(Pdb) url1
['https://esgf.ceda.ac.uk/data/esg_cmip7/MIP-DRS7/CMIP7/CMIP/UKNCSP/UKESM1-3-LL/esm-hist/r1i1p1f1/glb/mon/tas/tavg-h2m-hxy-u/g110/v20260814/tas_tavg-h2m-hxy-u_mon_glb_g110_UKESM1-3-LL_esm-hist_r1i1p1f1_185001-194912.nc|application/netcdf|HTTPServer']
```

This PR moves the unquoting inside the loop over files, applying it to each `file_rec` rather than to `last_file` outside the loop.