### PR TITLE
Improve cmip6 migration

### DIFF
--- a/src/python/esgcet/cli/__init__.py
+++ b/src/python/esgcet/cli/__init__.py
@@ -10,6 +10,23 @@ app = typer.Typer(name="esgcet", no_args_is_help=True)
 
 # Add subcommands from other modules
 app.add_typer(kerchunk.app, name="kerchunk")
-app.add_typer(publisher.app, name="publish")
 app.add_typer(qc_check.app, name="qc-check")
 app.add_typer(migrate2stac.app, name="migrate2stac")
+
+app.add_typer(
+    kerchunk.app,
+    name="kerchunk",
+    help="Generate Kerchunks from a map file or a directory with multiple map files.",
+)
+
+app.add_typer(
+    qc_check.app,
+    name="qc-check",
+    help="Run quality-control checks on datasets.",
+)
+
+app.add_typer(
+    migrate2stac.app,
+    name="migrate2stac",
+    help="Migrate ESGF1.5 metadata to STAC.",
+)

--- a/src/python/esgcet/cli/migrate2stac.py
+++ b/src/python/esgcet/cli/migrate2stac.py
@@ -21,6 +21,7 @@ def esgf15(
     institution_id: str = typer.Argument(help="institution id"),
     data_node: Literal["anl", "ornl", "nersc"] = typer.Argument(help="data node name"),
     project: str = typer.Argument(help="project name", callback=_validate_project),
+    is_replica: bool = typer.Option(help="is replica?", default=False),
     dataset_limit: int = typer.Option(help="dataset limit for each batch query", default=1000),
     config_file: str | None = typer.Option(
         help="config yaml file path, default will read the esg.yaml under $HOME/.config/esg_publisher"
@@ -33,6 +34,7 @@ def esgf15(
         institution_id = institution_id,
         data_node = data_node, 
         project = project,
+        is_replica = is_replica,
         dataset_limit = dataset_limit,
         config_file = config_file,
         total = total,

--- a/src/python/esgcet/esgf15/globus.py
+++ b/src/python/esgcet/esgf15/globus.py
@@ -1,5 +1,6 @@
 
 from enum import Enum
+import json
 
 from globus_sdk import (
     SearchClient,
@@ -60,14 +61,13 @@ class ESGFGlobusIndex:
         self.marker = None
 
     @staticmethod
-    def _generate_query_str(
+    def _generate_query_dict(
         meta_type: Literal['File', 'Dataset'],
         project: Project,
         fixed_facet: dict[str, Any],
         data_node: str,
         is_replica: bool = False,
-        dataset_limit: int = 1000,
-    ) -> SearchScrollQuery:
+    ) -> dict[str, Any]:
         
         query_dict= {"filters":[]}
         for key, val in fixed_facet.items():
@@ -101,26 +101,16 @@ class ESGFGlobusIndex:
             }
         )
 
-        if is_replica:
-            query_dict["filters"].append(
-                {
-                    "field_name": "replica",
-                    "values": [True],
-                    "type": "match_all",
-                }
-            )
-        else:
-            query_dict["filters"].append(
-                {
-                    "field_name": "replica",
-                    "values": [False],
-                    "type": "match_all",
-                }
-            )
+        query_dict["filters"].append(
+            {
+                "field_name": "replica",
+                "values": [is_replica],
+                "type": "match_all",
+            }
+        )
 
-        query_str = SearchScrollQuery(limit=dataset_limit, additional_fields=query_dict)
 
-        return query_str
+        return query_dict
 
 
     def query_dataset_file(
@@ -134,52 +124,47 @@ class ESGFGlobusIndex:
         """query index using project and a fixed_facet"""
 
         
-        query_str = self._generate_query_str(
+        query_dict_dset = self._generate_query_dict(
             'Dataset', 
             project, 
             fixed_facet, 
             data_node, 
             is_replica,
-            dataset_limit,
         )
+        query_str = SearchScrollQuery(limit=dataset_limit, additional_fields=query_dict_dset)
         paginator = self.query_client.paginated.scroll(self.index_id, query_str) 
 
+        query_dict_file = self._generate_query_dict(
+            'File',
+            project,
+            fixed_facet,
+            data_node,
+            is_replica,
+        )
 
-        query_dict = {
-            "filters": [
-                {
-                    "field_name": "data_node",
-                    "values": [data_node],
-                    "type": "match_any",
-                },
-                {
-                    "field_name": 'type',
-                    "values": ["File"],
-                    "type": "match_all",
-                },
-                {
-                    "field_name": "replica",
-                    "values": [is_replica],
-                    "type": "match_all",
-                },
-            ],
-            "sort": [
-                {
-                    "field_name": "id", 
-                    "order": "asc"
-                }
-            ],
-        }
+        query_dict_file["sort"] = [
+            {
+                "field_name": "id",
+                "order": "asc"
+            }
+        ]
 
         for response in paginator:
+
+            if response.data['total'] == 0:
+                raise ValueError(
+                    "Cannot find any dataset using the query filter:\n"
+                    f"{json.dumps(query_dict_dset)}"
+                )
+
             self.marker = response.data.get('marker')
             result_dict = defaultdict(list)
             dataset_ids = []
-            for g in response["gmeta"]:
+            for g in response.data["gmeta"]:
                 dataset_ids.append(g["subject"])
                 result_dict[g["subject"]] = [g["entries"][0]["content"]]
 
-            query_dict["filters"].append(
+            query_dict_file["filters"].append(
                 {
                     "field_name": "dataset_id",
                     "values": dataset_ids,
@@ -192,12 +177,12 @@ class ESGFGlobusIndex:
                 SearchQueryV1(
                     limit=10000,
                     offset =0,
-                    filters=query_dict["filters"],
-                    sort=query_dict["sort"]
+                    filters=query_dict_file["filters"],
+                    sort=query_dict_file["sort"]
                 )
             )
 
-            del query_dict["filters"][-1]
+            del query_dict_file["filters"][-1]
 
             if search_result["total"] > 10000:
                 raise ValueError("Over Globus post search limit, reduce the limit_dataset")

--- a/src/python/esgcet/esgf15/migrate_esgf15_stac.py
+++ b/src/python/esgcet/esgf15/migrate_esgf15_stac.py
@@ -25,6 +25,7 @@ def migrate(*,
     institution_id: str,
     data_node: Literal["anl", "ornl", "nersc"],
     project: Project,
+    is_replica: bool = False,
     dataset_limit: int = 1000,
     config_file: Path | None,
     total: int | None = None,
@@ -67,9 +68,13 @@ def migrate(*,
 
     esgf15_generator = esgf15_index.query_dataset_file(
         project = project,
-        fixed_facet = {"institution_id": institution_id},
+        fixed_facet = {
+            "institution_id": institution_id,
+            "latest": True,
+            "retracted": False,
+        },
         data_node = DATA_NODE_MAPPING[data_node],
-        is_replica = True,
+        is_replica = is_replica,
         dataset_limit = dataset_limit,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "esgcet"
-version = "5.5.0a0"
+version = "5.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
-  improve the code logic and reduce code duplication in the globus query functions
-  add `latest=True and retracted=False` in all globus queries 
-  add `--is-replica` option to the CMIP6/CMIP6Plus migration cli `migrate2stac` 
-  add descriptions for the `esgcet` subcommands