### PR TITLE
Change calculation of coordinate ranges

### DIFF
--- a/src/python/esgcet/scan/mk_dataset_xarray.py
+++ b/src/python/esgcet/scan/mk_dataset_xarray.py
@@ -170,10 +170,6 @@ class ESGPubXArrayHandler(ESGPubHandlerBase):
         if stdname != "time":
             var = self._undo_time_broadcast(var)
 
-        # Get the min, max range in the same way both for a 1d coordinate axis
-        # and also for an irregular grid.  With a 1d axis, in fact we only
-        # need to inspect a couple of elements, but the extra work here is not
-        # very expensive, and the code is simpler.
         shape = var.shape
 
         if stdname == "longitude":

--- a/src/python/esgcet/scan/mk_dataset_xarray.py
+++ b/src/python/esgcet/scan/mk_dataset_xarray.py
@@ -158,10 +158,10 @@ class ESGPubXArrayHandler(ESGPubHandlerBase):
         if (bounds_var_name is not None
             and bounds_var_name in scanobj.variables):
             var = scanobj[bounds_var_name]
-            self.publog.info(f"{stdname} has bounds var")
+            self.publog.debug(f"{stdname} has bounds var")
             using_bounds = True
         else:
-            self.publog.info(f"{stdname} no bounds var")
+            self.publog.debug(f"{stdname} no bounds var")
             using_bounds = False
 
         # undo any broadcasting in time that xarray may have done

--- a/src/python/esgcet/scan/mk_dataset_xarray.py
+++ b/src/python/esgcet/scan/mk_dataset_xarray.py
@@ -2,19 +2,34 @@ import xarray, netCDF4
 from esgcet.scan.handler_base import ESGPubHandlerBase
 import os.path
 import numpy as np
+import re
 
 class ESGPubXArrayHandler(ESGPubHandlerBase):
 
     @staticmethod
     def xarray_load(map_data):
-        datafile = map_data[0][1]
-        destpath = os.path.dirname(datafile)
+        filenames = [row[1] for row in map_data]
+        if len(filenames) > 1:
 
-        filespec = f"{destpath}/*.nc"
+            # optimise: only need first and last file (in sorted order) to correctly evaluate
+            # data time range, if filenames all follow a common pattern but with a numeric
+            # date string - see if they all have the same normalised filename (after
+            # replacing actual digits with <DIGIT>)
+            #
+            # This saves time and memory for long timeseries.
+            #
+            # The assets dictionary is populated directly from the mapfile data, and is
+            # not affected by this.
+
+            if len({re.sub(r"\d", "<DIGIT>", filename)
+                    for filename in filenames}) == 1:
+                # use min() and max() rather than [0] and [-1] because esgmapfile might not
+                # have created the lines in sorted order
+                filenames = [min(filenames), max(filenames)]
 
         time_coder = xarray.coders.CFDatetimeCoder(use_cftime=True)
         res = xarray.open_mfdataset(
-            filespec,
+            filenames,
             decode_times=time_coder,
             data_vars='all'
         )
@@ -45,81 +60,177 @@ class ESGPubXArrayHandler(ESGPubHandlerBase):
         return [x for x in variable]
 
     def _get_time_str(self, timeval):
-        if type(timeval.item()) is float or type(timeval.item()) is int:
+        if hasattr(timeval, "item"):
+            timeval = timeval.item()
+        if type(timeval) is float or type(timeval) is int:
             x = str(timeval)
             idx = x.index('.')
             return x[:idx] + 'Z'
         else:
-            return timeval.item().isoformat(timespec="seconds") + "Z"
+            return timeval.isoformat(timespec="seconds") + "Z"
+
+
+    def _get_item(self, obj):
+        if hasattr(obj, "compute"):
+            obj = obj.compute()
+        return obj.item()
+
+
+    def _undo_time_broadcast(self, var):
+        dims = var.dims
+        if dims and dims[0] == "time":
+            return var[0]
+        else:
+            return var
+
+
+    def _get_longitude_range(self, longitudes,
+                             global_threshold=350.):
+        """
+        Given a scatter of longitude points, returns the west and east extremes.
+
+        This is done by sorting them and locating the biggest "gap" (arc of circle),
+        but subject to a threshold that if the range spanned is close to 360,
+        then treating it as global.
+        """
+        x = np.asarray(longitudes, dtype=float).ravel()
+        x = x[np.isfinite(x)]
+
+        if len(x) == 0:
+            raise ValueError("No finite longitude values")
+
+        # Identify the convention used by the input data.
+        if np.all((x >= 0) & (x <= 360)):
+            globe_start = 0.
+        else:
+            globe_start = -180.
+
+        x = np.sort(x)
+
+        # If necessary, normalise
+        if x[0] < 0 or x[-1] > 360 or x[-1] - x[0] >= 360:
+            x = x % 360
+            x = np.sort(x)
+
+        if len(x) == 1 or x[0] == x[-1]:
+            return x[0], x[0]
+
+        wrap_gap = (x[0] - x[-1]) % 360
+        gaps = np.append(np.diff(x) % 360, wrap_gap)
+
+        # largest empty arc
+        i = np.argmax(gaps)
+        largest_gap = gaps[i]
+        span = 360 - largest_gap
+
+        if span >= global_threshold:
+            # virtually global per heuristic, so return global range
+            #  (-180,180 or 0,360 as per the data)
+            return globe_start, globe_start + 360
+
+        start = x[(i + 1) % len(x)]
+        end = x[i]
+        lon_min = (start - globe_start) % 360 + globe_start
+        lon_max = (end - globe_start) % 360 + globe_start
+        if lon_max == globe_start:
+            lon_max += 360
+        return lon_min, lon_max
+
+
+    def _min_and_max(self, a, b):
+        if a < b:
+            return a, b
+        else:
+            return b, a
+
+
+    def _get_min_max_bounds(self, scanobj, var):
+
+        if var.name not in scanobj.coords:
+            raise ValueError("_get_min_max_bounds called on "
+                             f"non-coordinate variable {var.name}")
         
-    def _get_min_max_bounds(self, latlon):
-        bigarr = latlon[0] + latlon[-1]
-        return float(np.min(bigarr)), float(np.max(bigarr))
-    
+        stdname = var.attrs.get("standard_name")
+
+        # use the bounds variable instead if available, so that the range
+        # that is returned will include the bounds and not just the central value
+        bounds_var_name = var.attrs.get("bounds")
+        if (bounds_var_name is not None
+            and bounds_var_name in scanobj.variables):
+            var = scanobj[bounds_var_name]
+            self.publog.info(f"{stdname} has bounds var")
+            using_bounds = True
+        else:
+            self.publog.info(f"{stdname} no bounds var")
+            using_bounds = False
+
+        # undo any broadcasting in time that xarray may have done
+        # for non-time variable (seems to do this for vertices array
+        # of original shape (ny, nx, 4) when opening multiple files)
+        if stdname != "time":
+            var = self._undo_time_broadcast(var)
+
+        # Get the min, max range in the same way both for a 1d coordinate axis
+        # and also for an irregular grid.  With a 1d axis, in fact we only
+        # need to inspect a couple of elements, but the extra work here is not
+        # very expensive, and the code is simpler.
+        shape = var.shape
+
+        if stdname == "longitude":
+            # For longitude, always use the same algorithm, regardless of whether it is
+            # 1d or 2d coord var.  (For 1d, we might need to unnecessarily inspect *all*
+            # the longitudes, but it won't be expensive, and it simplifies some other
+            # complexity.)
+            minmax = self._get_longitude_range(var.values)
+
+        else:
+            # Otherwise, try not to compute all the values unless it is actually 2d.
+            # This is particularly important for the time axis.
+            if not using_bounds and len(shape) == 1:
+                # 1d coord variable
+                minmax = self._min_and_max(self._get_item(var[0]),
+                                           self._get_item(var[-1]))
+            elif using_bounds and len(shape) == 2 and shape[1] == 2:
+                # bounds variable of expected shape for 1d coordinate variable
+                minmax = self._min_and_max(self._get_item(var[0, 0]),
+                                           self._get_item(var[-1, 1]))
+            else:
+                vals = var.values
+                minmax = (vals.min(), vals.max())
+
+        return minmax
+
+
+    def _get_coord_var_by_stdname(self, scanobj, stdname):
+        for coord in scanobj.coords:
+            var = scanobj[coord]
+            if var.attrs.get("standard_name") == stdname:
+                return var
+        return None
+
+
     def set_bounds(self, record, scanobj):
 
         geo_units = []
-        # latitude
-        if "lat" in scanobj.coords:
-            lat = scanobj.coords["lat"]
-            if len(lat) > 0:
-                record["north_degrees"] = float(lat.values.max())
-                record["south_degrees"] = float(lat.values.min())
-            else:
-                self.publog.warn("'lat' found but len 0")          
-        elif "latitude" in scanobj.coords:
-            lat = scanobj.coords["latitude"]
-            if len(lat) > 0:
-                if isinstance(lat[0].values, (list, np.ndarray)):
-                    minval, maxval = self._get_min_max_bounds(lat)
-                    record["north_degrees"] = minval
-                    record["south_degrees"] = maxval
 
-                else:    
-                    record["north_degrees"] = lat[-1].values.item()
-                    record["south_degrees"] = lat[0].values.item()
-                geo_units.append(lat.units)
-            else:
-                self.publog.warn("Latitude found but len 0")
-        else:
-            self.publog.warn("Lat/Latitude not found")
-        # longitude
-        if "lon" in scanobj.coords:
-            lon = scanobj.coords["lon"]
-            if len(lon) > 0:
-                record["east_degrees"] = float(lon.values.max())
-                record["west_degrees"] = float(lon.values.min())
-            else:
-                self.publog.warn("'lon' found but len 0")          
-        elif "longitude" in scanobj.coords:
-            lon = scanobj.coords["longitude"]
-            if len(lon) > 0:
-                if isinstance(lon[0].values, (list, np.ndarray)):
-                    minval, maxval = self._get_min_max_bounds(lon)   
-                    record["east_degrees"] = float(minval)
-                    record["west_degrees"] = float(maxval)
+        for (stdname, bounds_names, conv) in [
+                ("latitude", ("south_degrees", "north_degrees"), None),
+                ("longitude", ("west_degrees", "east_degrees"), None),
+                ("time", ("datetime_start", "datetime_end"), self._get_time_str),
+                ("air_pressure", ("height_top", "height_bottom"), None),
+        ]:
+
+            var = self._get_coord_var_by_stdname(scanobj, stdname)
+            if var is not None:
+                if len(var.shape) > 0 and var.size > 0:
+                    minmax = self._get_min_max_bounds(scanobj, var)
+                    if conv is not None:
+                        minmax = (conv(minmax[0]), conv(minmax[1]))
+                    record[bounds_names[0]], record[bounds_names[1]] = minmax
+                    if "units" in var.attrs:
+                        geo_units.append(var.units)
                 else:
-                    record["east_degrees"] = float(lon[-1].values.item())
-                    record["west_degrees"] = float(lon[0].values.item())
-                geo_units.append(lon.units)
-            else:
-                self.publog.warn("Latitude found but len 0")
-                # time
-        else:
-            self.publog.warn("Lon/Longitude not found")
-        if "time" in scanobj.coords:
-            ti = scanobj.coords["time"]
-            record["datetime_start"] = self._get_time_str(ti[0].values)
-            record["datetime_end"] = self._get_time_str(ti[-1].values)
-        # plev
-        if "plev" in scanobj.coords:
-            try:
-                plev = scanobj.coords["plev"]
-                record["height_top"] = plev[0].values.item() 
-                record["height_bottom"] = plev[-1].values.item() 
-                geo_units.append(plev.units)
-            except:
-                self.publog.warn("plev found but not an expected type")
+                    self.publog.warn(f"{stdname} found but len 0")
+
         if len(geo_units) > 0:
             record["geo_units"] = geo_units
-            

--- a/src/python/esgcet/stac/stac_converter.py
+++ b/src/python/esgcet/stac/stac_converter.py
@@ -203,19 +203,35 @@ class ESGSTACConverter:
             self.publog.error(f"No assets found for {item_id}")
             return None
 
-        west_degrees = dataset_doc.get("west_degrees", -180.0)
-        south_degrees = dataset_doc.get("south_degrees", -90.0)
-        east_degrees = dataset_doc.get("east_degrees", 180.0)
-        north_degrees = dataset_doc.get("north_degrees", 90.0)
+        west_degrees = float(dataset_doc.get("west_degrees", -180.0))
+        south_degrees = float(dataset_doc.get("south_degrees", -90.0))
+        east_degrees = float(dataset_doc.get("east_degrees", 180.0))
+        north_degrees = float(dataset_doc.get("north_degrees", 90.0))
 
-        if namespace.startswith("cmip"):
-            west_degrees -= 180
-            east_degrees -= 180
-        # STAC needs longitude in range [-180, 180], but CF might use [0, 360]
-        if west_degrees > 180:
-            west_degrees -= 360
-        if east_degrees > 180:
-            east_degrees -= 360
+        # STAC needs longitude in range [-180, 180], but CF might use [0, 360)
+
+        if abs(east_degrees - west_degrees - 360) < 1e-3:
+            # represent any global range (e.g. 0 to 360 or -180 to 180 in the data)
+            # as -180 to 180
+            west_degrees, east_degrees = -180., 180.
+        else:
+            # otherwise force each value separately to range [-180, 180) (for west)
+            # or (-180, 180] (for east)
+            west_degrees = (west_degrees + 180) % 360 - 180
+            east_degrees = (east_degrees + 180) % 360 - 180
+
+            if east_degrees == -180.:
+                east_degrees = 180.
+
+        if south_degrees < -90.:
+            func = self.publog.info if south_degrees > -90.001 else self.publog.warning
+            func(f"forcing min lat {south_degrees} into range (-90)")
+            south_degrees = -90.
+
+        if north_degrees > 90.:
+            func = self.publog.info if north_degrees < 90.001 else self.publog.warning
+            func(f"forcing max lat {north_degrees} into range (90)")
+            north_degrees = 90.
 
         dt_start = dataset_doc.get("datetime_start", None)
         dt_end = dataset_doc.get("datetime_end", None)

--- a/tests/unit/test_stac_converter.py
+++ b/tests/unit/test_stac_converter.py
@@ -321,7 +321,7 @@ class TestESGSTACConverter:
         converter = ESGSTACConverter(stac_config)
         item = converter.convert2stac([dataset, cmip6_file_doc])
 
-        assert item["bbox"] == [-140.0, -90.0, -40.0, 90.0]
+        assert item["bbox"] == [40.0, -90.0, 140.0, 90.0]
 
     def test_convert_default_datetime(self, stac_config, cmip6_file_doc):
         """Test default datetime when start/end not provided."""


### PR DESCRIPTION
This pull request changes how coordinate ranges are calculated from the data in the publisher.

This fixes some erroneous calculations that were giving completely wrong ranges in some situations, such that STAC would reject the publication during schema validation, but it also has minor improvements in other cases, in particular as regards the use of bounds coordinates (including for time, so for example, a year of monthly mean data that might give a time range from mid-Jan to mid-Dec will instead give the whole year).   I have tested it with a range of CMIP6 models, as well as some MOHC CMIP7 data, and seems okay, including with some zonal mean data, and data on tripolar grid, that otherwise would not publish.

I have also included a change to which data files are scanned.  Rather than scanning all of the datafiles (which is expensive), it only actually needs the first and last by filename (at least in the case where the filenames only differ by containing different digits).  See the first comment block below.