### PR TITLE
Reapply "implemented --save-stac flag for EAST publishing node."

### DIFF
--- a/src/python/esgcet/stac/stac_client.py
+++ b/src/python/esgcet/stac/stac_client.py
@@ -191,6 +191,8 @@ class EGITransactionClient:
     """EGI Transaction client for publishing ESGF items."""
 
     def __init__(self, args):
+        self.dry_run = args.get("dry_run", False)
+        self.save_stac = args.get("save_stac", False)
         verbose = args.get("verbose", False)
         silent = args.get("silent", False)
         self.publog = log.return_logger("STAC Client", silent, verbose)
@@ -234,6 +236,14 @@ class EGITransactionClient:
         headers = {
             "User-Agent": f"esgf_publisher/{__version__}",
         }
+
+        if self.save_stac:
+            with open(f"{entry['id']}.json", "w") as f:
+                f.write(json.dumps(entry, indent=1))
+
+        if self.dry_run:
+            self.publog.info("Dry-run mode: Not publishing")
+            return True
 
         try:
             response = requests.post(

--- a/tests/unit/test_stac_client.py
+++ b/tests/unit/test_stac_client.py
@@ -1,0 +1,46 @@
+"""Tests for STAC transaction clients."""
+
+import json
+
+from esgcet.stac import stac_client
+from esgcet.stac.stac_client import EGITransactionClient
+
+
+def test_egi_save_stac_writes_item_before_dry_run(tmp_path, monkeypatch):
+    """The EGI client saves an item locally without publishing in dry-run mode."""
+    monkeypatch.chdir(tmp_path)
+
+    def unexpected_post(*args, **kwargs):
+        raise AssertionError("dry-run must not send a request")
+
+    monkeypatch.setattr(stac_client.requests, "post", unexpected_post)
+    client = EGITransactionClient(
+        {
+            "stac_api": "https://stac.example.test",
+            "save_stac": True,
+            "dry_run": True,
+        }
+    )
+    entry = {
+        "id": "CMIP6.example.dataset.v1",
+        "collection": "CMIP6",
+        "type": "Feature",
+    }
+
+    assert client.publish(entry) is True
+    assert json.loads((tmp_path / f"{entry['id']}.json").read_text()) == entry
+
+
+def test_egi_does_not_save_stac_by_default(tmp_path, monkeypatch):
+    """Local persistence remains opt-in for the EGI client."""
+    monkeypatch.chdir(tmp_path)
+    client = EGITransactionClient(
+        {
+            "stac_api": "https://stac.example.test",
+            "dry_run": True,
+        }
+    )
+    entry = {"id": "CMIP6.example.dataset.v1", "collection": "CMIP6"}
+
+    assert client.publish(entry) is True
+    assert not (tmp_path / f"{entry['id']}.json").exists()


### PR DESCRIPTION
This PR implements the same behaviour of --save-stac when using the EAST node 