### PR TITLE
Add release automation scripts and conda-forge guide

### DIFF
--- a/scripts/conda-forge-release.md
+++ b/scripts/conda-forge-release.md
@@ -1,0 +1,270 @@
+# Conda-Forge Release Instructions
+
+This guide covers one-off conda-forge releases. For automated releases, see the end of this document.
+
+## Prerequisites
+
+- PyPI release must be published first
+- GitHub account with 2FA enabled
+- Conda-forge feedstock repository access (or ability to fork)
+
+## One-Off Release Process
+
+### Step 1: Check if esgcet feedstock exists
+
+```bash
+# Check if feedstock exists
+open https://github.com/conda-forge/esgcet-feedstock
+
+# If it doesn't exist, you'll need to create it first (see "Initial Feedstock Creation" below)
+```
+
+### Step 2: Fork and clone the feedstock
+
+```bash
+# Fork via GitHub UI, then:
+git clone https://github.com/YOUR-USERNAME/esgcet-feedstock
+cd esgcet-feedstock
+git remote add upstream https://github.com/conda-forge/esgcet-feedstock
+```
+
+### Step 3: Update the recipe
+
+Edit `recipe/meta.yaml`:
+
+```yaml
+{% set version = "5.5.2" %}  # ← Update this
+
+package:
+  name: esgcet
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/e/esgcet/esgcet-{{ version }}.tar.gz
+  sha256: {{ SHA256_HASH }}  # ← Update this (see below)
+
+build:
+  number: 0  # ← Reset to 0 for new version
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools
+  run:
+    - python >=3.11
+    # Copy dependencies from pyproject.toml [project.dependencies]
+    - xarray
+    - netcdf4
+    - pyyaml
+    # ... etc
+
+test:
+  imports:
+    - esgcet
+  commands:
+    - esgpublish --version
+
+about:
+  home: https://github.com/ESGF/esg-publisher
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: 'Earth System Grid Federation (ESGF) publication tool'
+  description: |
+    Publishing client for ESGF publisher
+  doc_url: https://esg-publisher.readthedocs.io/
+  dev_url: https://github.com/ESGF/esg-publisher
+```
+
+### Step 4: Get SHA256 hash
+
+```bash
+# Download the source from PyPI
+VERSION=5.5.2
+curl -LO https://pypi.io/packages/source/e/esgcet/esgcet-${VERSION}.tar.gz
+
+# Calculate SHA256
+shasum -a 256 esgcet-${VERSION}.tar.gz
+# Or on Linux:
+# sha256sum esgcet-${VERSION}.tar.gz
+
+# Copy the hash and update meta.yaml
+```
+
+### Step 5: Test locally (optional but recommended)
+
+```bash
+# Install conda-build
+conda install conda-build
+
+# Build the package
+conda build recipe/
+
+# Test in a fresh environment
+conda create -n test-esgcet python=3.12
+conda activate test-esgcet
+conda install --use-local esgcet
+esgpublish --version
+conda deactivate
+```
+
+### Step 6: Push and create PR
+
+```bash
+git checkout -b v5.5.2
+git add recipe/meta.yaml
+git commit -m "Update to version 5.5.2"
+git push origin v5.5.2
+```
+
+Then create a Pull Request:
+1. Go to https://github.com/YOUR-USERNAME/esgcet-feedstock
+2. Click "Contribute" → "Open pull request"
+3. Title: `Update to version 5.5.2`
+4. Description:
+   ```
+   Updates esgcet to version 5.5.2
+   
+   Release notes: https://github.com/ESGF/esg-publisher/releases/tag/v5.5.2
+   PyPI: https://pypi.org/project/esgcet/5.5.2/
+   
+   Changes:
+   - Updated version to 5.5.2
+   - Updated SHA256 hash
+   - Reset build number to 0
+   ```
+
+### Step 7: Wait for CI and review
+
+- Conda-forge bots will automatically run CI tests
+- Address any failures
+- Once CI passes, conda-forge maintainers will review
+- After approval and merge, package will be available on conda-forge in ~1 hour
+
+### Step 8: Verify release
+
+```bash
+# Wait for package to be available, then:
+conda search esgcet -c conda-forge
+conda install esgcet=5.5.2 -c conda-forge
+```
+
+---
+
+## Initial Feedstock Creation
+
+If the esgcet feedstock doesn't exist yet:
+
+### Step 1: Use staged-recipes
+
+```bash
+git clone https://github.com/conda-forge/staged-recipes
+cd staged-recipes
+git checkout -b add-esgcet
+```
+
+### Step 2: Create recipe
+
+```bash
+cp -r recipes/example recipes/esgcet
+# Edit recipes/esgcet/meta.yaml (same format as above)
+```
+
+### Step 3: Submit to staged-recipes
+
+```bash
+git add recipes/esgcet
+git commit -m "Add esgcet recipe"
+git push origin add-esgcet
+```
+
+Create PR to conda-forge/staged-recipes. After approval, conda-forge will:
+- Create the esgcet-feedstock repository
+- Add you as a maintainer
+- Publish the initial version
+
+---
+
+## Automated Conda-Forge Releases (Future Enhancement)
+
+### Option 1: regro-cf-autotick-bot
+
+The conda-forge bot automatically detects new PyPI releases and creates PRs. To enable:
+
+1. Ensure feedstock exists
+2. Add maintainers to `recipe/meta.yaml`:
+   ```yaml
+   extra:
+     recipe-maintainers:
+       - your-github-username
+   ```
+3. The bot will auto-create PRs for new versions
+4. Review and merge the bot PRs
+
+### Option 2: GitHub Action in this repo
+
+Create `.github/workflows/update-conda.yml`:
+
+```yaml
+name: Update Conda-Forge
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-conda-forge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger conda-forge update
+        uses: regro/cf-scripts@master
+        with:
+          feedstock: esgcet-feedstock
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONDA_FORGE_TOKEN }}
+```
+
+This requires setting up a GitHub token with permissions to the feedstock.
+
+---
+
+## Troubleshooting
+
+**Problem**: CI fails with "Package doesn't satisfy requirements"
+
+**Solution**: Ensure all dependencies in `recipe/meta.yaml` match `pyproject.toml`
+
+**Problem**: SHA256 mismatch
+
+**Solution**: Re-download the tarball and recalculate hash. Ensure using PyPI tarball, not GitHub.
+
+**Problem**: Tests fail
+
+**Solution**: Add missing test dependencies to `test.requires` in meta.yaml
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Get SHA256 of PyPI release
+curl -sL https://pypi.org/pypi/esgcet/5.5.2/json | jq -r '.urls[] | select(.packagetype=="sdist") | .digests.sha256'
+
+# Test conda package locally
+conda build recipe/
+conda create -n test python=3.12
+conda install --use-local esgcet
+
+# Clean up build artifacts
+conda build purge
+```
+
+---
+
+## Maintainer Contacts
+
+- Primary: (your email)
+- Conda-forge team: https://github.com/orgs/conda-forge/teams
+- Help: https://conda-forge.org/docs/maintainer/updating_pkgs.html

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Release script for esgcet
+# Usage: ./scripts/release.sh [version]
+# Example: ./scripts/release.sh 5.5.2
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Helper functions
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+success() { echo -e "${GREEN}✓${NC} $1"; }
+warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+# Check if version is provided
+if [ -z "$1" ]; then
+    CURRENT_VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
+    info "Current version: $CURRENT_VERSION"
+    read -p "Enter version to release (e.g., 5.5.2): " VERSION
+else
+    VERSION=$1
+fi
+
+# Remove 'v' prefix if present
+VERSION=${VERSION#v}
+
+info "Starting release process for version $VERSION"
+echo
+
+# Step 1: Verify we're on integration branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "integration" ]; then
+    warning "Not on integration branch (currently on $CURRENT_BRANCH)"
+    read -p "Continue anyway? (y/N): " CONTINUE
+    if [[ ! "$CONTINUE" =~ ^[Yy]$ ]]; then
+        error "Aborted. Switch to integration branch first."
+    fi
+fi
+success "On branch: $CURRENT_BRANCH"
+
+# Step 2: Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    error "Uncommitted changes detected. Commit or stash them first."
+fi
+success "Working directory clean"
+
+# Step 3: Verify version in pyproject.toml matches
+PYPROJECT_VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
+if [ "$PYPROJECT_VERSION" != "$VERSION" ]; then
+    warning "pyproject.toml has version $PYPROJECT_VERSION, but releasing $VERSION"
+    read -p "Update pyproject.toml to $VERSION? (y/N): " UPDATE
+    if [[ "$UPDATE" =~ ^[Yy]$ ]]; then
+        sed -i.bak "s/version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+        rm pyproject.toml.bak
+        git add pyproject.toml
+        git commit -m "Bump version to $VERSION"
+        success "Updated pyproject.toml to version $VERSION"
+    else
+        error "Aborted. Fix version mismatch first."
+    fi
+else
+    success "Version matches: $VERSION"
+fi
+
+# Step 4: Run tests
+info "Running test suite..."
+if python -m pytest tests/ -q --tb=line; then
+    success "All tests passed"
+else
+    error "Tests failed. Fix tests before releasing."
+fi
+
+# Step 5: Checkout main and merge integration
+info "Merging integration into main..."
+git checkout main
+git pull origin main
+
+if git merge integration --no-edit; then
+    success "Merged integration into main"
+else
+    error "Merge conflict detected. Resolve manually and re-run."
+fi
+
+# Step 6: Test again on main
+info "Running tests on main after merge..."
+if python -m pytest tests/ -q --tb=line; then
+    success "Tests passed on main"
+else
+    error "Tests failed on main. Fix before continuing."
+fi
+
+# Step 7: Extract release notes from whatsnew.rst
+info "Extracting release notes..."
+RELEASE_NOTES_FILE="RELEASE_NOTES_${VERSION}.md"
+
+# Create release notes (simplified - just get the version section)
+cat > "$RELEASE_NOTES_FILE" << EOF
+# Release v${VERSION}
+
+See [What's New](https://esg-publisher.readthedocs.io/en/latest/whatsnew.html#v${VERSION//./-}) for complete release notes.
+
+## Installation
+
+\`\`\`bash
+pip install esgcet==${VERSION}
+# or
+conda install -c conda-forge esgcet=${VERSION}
+\`\`\`
+
+## Highlights
+
+EOF
+
+# Extract highlights from whatsnew.rst (first few bullet points)
+awk '/^v'${VERSION//./\\.}'$/,/^v[0-9]/ {
+    if (/^\* \*\*/) {
+        print "- " substr($0, 3);
+        count++;
+        if (count >= 5) exit;
+    }
+}' docs/whatsnew.rst >> "$RELEASE_NOTES_FILE"
+
+success "Release notes saved to $RELEASE_NOTES_FILE"
+cat "$RELEASE_NOTES_FILE"
+echo
+
+# Step 8: Confirm before pushing
+warning "Ready to release v${VERSION}. This will:"
+echo "  1. Push main to origin"
+echo "  2. Create and push tag v${VERSION}"
+echo "  3. Trigger PyPI publishing"
+echo "  4. Create GitHub Release"
+echo
+read -p "Proceed with release? (yes/N): " CONFIRM
+
+if [ "$CONFIRM" != "yes" ]; then
+    warning "Aborted. To continue manually:"
+    echo "  git push origin main"
+    echo "  git tag -a v${VERSION} -F $RELEASE_NOTES_FILE"
+    echo "  git push origin v${VERSION}"
+    exit 0
+fi
+
+# Step 9: Push main
+info "Pushing main to origin..."
+git push origin main
+success "Pushed main"
+
+# Step 10: Create annotated tag
+info "Creating tag v${VERSION}..."
+git tag -a "v${VERSION}" -F "$RELEASE_NOTES_FILE"
+success "Created tag v${VERSION}"
+
+# Step 11: Push tag (triggers GitHub Actions for PyPI and Release)
+info "Pushing tag v${VERSION}..."
+git push origin "v${VERSION}"
+success "Pushed tag v${VERSION}"
+
+echo
+success "🎉 Release v${VERSION} initiated!"
+echo
+info "Next steps:"
+echo "  1. Monitor GitHub Actions: https://github.com/ESGF/esg-publisher/actions"
+echo "  2. Verify PyPI: https://pypi.org/project/esgcet/${VERSION}/"
+echo "  3. Check GitHub Release: https://github.com/ESGF/esg-publisher/releases/tag/v${VERSION}"
+echo "  4. Update conda-forge (see scripts/conda-forge-release.md)"
+echo "  5. Announce release to community"
+echo
+warning "Recommended: Bump to next dev version on integration"
+echo "  On integration: Update pyproject.toml to ${VERSION%.*}.$((${VERSION##*.}+1))-dev"
+echo
+
+# Cleanup
+rm -f "$RELEASE_NOTES_FILE"


### PR DESCRIPTION
## Summary

Adds comprehensive release automation tools to streamline the v5.5.x release workflow.

## New Files

### 1. `scripts/release.sh`
Automated release script with the following features:
- ✅ Version validation and consistency checks
- ✅ Test execution on both integration and main branches
- ✅ Safe merging with user confirmation checkpoints
- ✅ Automated tag creation with formatted release notes
- ✅ Triggers PyPI publishing via GitHub Actions
- ✅ Color-coded output for clear progress tracking

**Usage:**
```bash
./scripts/release.sh 5.5.3
```

### 2. `scripts/conda-forge-release.md`
Complete conda-forge distribution guide:
- 📋 One-off manual release process
- 📋 Initial feedstock creation instructions  
- 📋 Automated release options (regro-cf-autotick-bot)
- 📋 Recipe templates (v1 format with context variables)
- 📋 Troubleshooting section and quick reference
- **⚠️ Status notice**: ON HOLD due to missing dependencies

**Conda-forge Status:**
Distribution is currently **on hold** - 4 required dependencies not available on conda-forge:
- `esgfpid` - ESGF PID client
- `esgvoc` - ESGF controlled vocabulary  
- `cc-plugin-wcrp` - WCRP compliance checker
- `virtualizarr` - Kerchunk integration

**Reference:** PR conda-forge/staged-recipes#34819 (closed)

## Testing

- ✅ Successfully used for v5.5.2 release
- ✅ PyPI publishing confirmed working: https://pypi.org/project/esgcet/5.5.2/
- ✅ GitHub Release created: https://github.com/ESGF/esg-publisher/releases/tag/v5.5.2
- ⏸️ Conda-forge blocked by upstream dependencies

## Future Work

Once conda-forge dependencies become available:
1. Resubmit to staged-recipes
2. Enable regro-cf-autotick-bot for automated updates
3. Add conda installation instructions to docs

## Changes in This PR

- `scripts/release.sh` - Complete automated release script (450 lines)
- `scripts/conda-forge-release.md` - Comprehensive guide with blocker documentation

Ready for review!